### PR TITLE
Use typed null for casts

### DIFF
--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -22,7 +22,7 @@ const commitTimestampPlaceholderString = "spanner.commit_timestamp()"
 
 var (
 	ErrCannotInferArrayElementType = errors.New("cannot infer element type for empty array literal without explicit type")
-	zeroGCV                       spanner.GenericColumnValue
+	zeroGCV                        spanner.GenericColumnValue
 )
 
 func typelessStructLiteralArgToNameWithGCV(arg ast.TypelessStructLiteralArg) (string, spanner.GenericColumnValue, error) {
@@ -187,7 +187,7 @@ func memefishCastExprToGCV(cast *ast.CastExpr) (spanner.GenericColumnValue, erro
 	}
 
 	if _, ok := cast.Expr.(*ast.NullLiteral); ok {
-		return gcvctor.SimpleTypedNull(destType.GetCode()), nil
+		return gcvctor.TypedNull(destType), nil
 	}
 
 	// Prioritize types without literals

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -122,6 +122,11 @@ func TestParseExpr(t *testing.T) {
 		{"CAST(NULL AS INT64)", gcvctor.SimpleTypedNull(sppb.TypeCode_INT64)},
 		{"CAST(NULL AS FLOAT64)", gcvctor.SimpleTypedNull(sppb.TypeCode_FLOAT64)},
 		{"CAST(NULL AS UUID)", gcvctor.SimpleTypedNull(sppb.TypeCode_UUID)},
+		{"CAST(NULL AS ARRAY<INT64>)", gcvctor.ArrayCodeTypedNull(sppb.TypeCode_INT64)},
+		{
+			"CAST(NULL AS STRUCT<foo INT64>)",
+			gcvctor.TypedNull(must(typector.NameCodeSlicesToStructType([]string{"foo"}, []sppb.TypeCode{sppb.TypeCode_INT64}))),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve full destination type information for `CAST(NULL AS ...)`
- cover typed `NULL` casts for array and struct targets in parser tests

## Why
- `gcvctor.SimpleTypedNull(destType.GetCode())` drops nested type information for complex types such as `ARRAY<INT64>` and `STRUCT<...>`
- `gcvctor.TypedNull(destType)` keeps the full destination type, which matches the intent of the cast

## Validation
- `go test ./...`
- `make lint`