### PR TITLE
Support array literal supertypes

### DIFF
--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -185,7 +185,7 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 	}
 
 	var first *sppb.Type
-	codes := make([]sppb.TypeCode, 0, len(gcvs))
+	codes := make([]sppb.TypeCode, 0, len(exprs))
 	for i, expr := range exprs {
 		if _, ok := unwrapParenExpr(expr).(*ast.NullLiteral); ok {
 			continue

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -291,8 +291,8 @@ func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 
 func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
 	// This is not the full CAST matrix. It only models array literal coercions
-	// that are safe locally; unsupported cases return an error so the caller can
-	// preserve the pre-existing permissive wire-value fallback.
+	// that are safe locally; CAST-only conversions such as FLOAT64 to NUMERIC
+	// and NUMERIC to FLOAT32 intentionally fall back to preserving wire values.
 	switch elemType.GetCode() {
 	case sppb.TypeCode_NUMERIC:
 		if gcv.Type.GetCode() == sppb.TypeCode_INT64 {
@@ -311,6 +311,8 @@ func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (sp
 }
 
 func coerceArrayElementToFloat32(gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	// Reuse scalar CAST helpers from cast.go so float narrowing and wire-value
+	// extraction stay consistent between CAST emulation and array coercion.
 	switch gcv.Type.GetCode() {
 	case sppb.TypeCode_INT64:
 		v, err := int64FromGCV(gcv)

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -3,6 +3,7 @@ package memebridge
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"slices"
 	"strconv"
 
@@ -14,6 +15,7 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/cloudspannerecosystem/memefish/ast"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -136,9 +138,8 @@ func MemefishExprToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 			return zeroGCV, err
 		}
 
-		// An explicit ARRAY<T> annotation takes precedence; otherwise infer from
-		// the first expression that carries type information.
-		// TODO: Detect a common supertype instead of picking the first typed element.
+		// An explicit ARRAY<T> annotation takes precedence; otherwise infer a
+		// local common supertype from the literal elements.
 		var typ *sppb.Type
 		if e.Type != nil {
 			// memefish stores the explicit type from ARRAY<T>[...] as the element type T,
@@ -179,13 +180,29 @@ func MemefishExprToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) *sppb.Type {
 	// exprs and gcvs are derived from the same ArrayLiteral.Values slice, so
 	// their indexes stay aligned here.
+	if len(exprs) == 0 {
+		return nil
+	}
+
+	var first *sppb.Type
+	codes := make([]sppb.TypeCode, 0, len(gcvs))
 	for i, expr := range exprs {
 		if _, ok := unwrapParenExpr(expr).(*ast.NullLiteral); ok {
 			continue
 		}
-		return gcvs[i].Type
+		if first == nil {
+			first = gcvs[i].Type
+		}
+		codes = append(codes, gcvs[i].Type.GetCode())
 	}
-	return nil
+	if first == nil {
+		return typector.Int64()
+	}
+
+	if typ := commonNumericArrayElementType(codes); typ != nil {
+		return typ
+	}
+	return first
 }
 
 func unwrapParenExpr(expr ast.Expr) ast.Expr {
@@ -205,6 +222,11 @@ func arrayLiteralValueOf(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 			return zeroGCV, err
 		}
 
+		coerced, coerceErr := coerceArrayElements(elemType, gcvs)
+		if coerceErr == nil {
+			return gcvctor.ArrayValueOf(elemType, coerced...)
+		}
+
 		// Preserve the current permissive behavior for array literals whose
 		// element values do not all match elemType. This intentionally keeps the
 		// original element wire values even when they disagree with elemType,
@@ -220,6 +242,110 @@ func arrayLiteralValueOf(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 	}
 
 	return gcvctor.ArrayValueOf(elemType, normalized...)
+}
+
+func commonNumericArrayElementType(codes []sppb.TypeCode) *sppb.Type {
+	if len(codes) == 0 {
+		return nil
+	}
+
+	hasInt64 := false
+	hasNumeric := false
+	hasFloat32 := false
+	hasFloat64 := false
+	for _, code := range codes {
+		switch code {
+		case sppb.TypeCode_INT64:
+			hasInt64 = true
+		case sppb.TypeCode_NUMERIC:
+			hasNumeric = true
+		case sppb.TypeCode_FLOAT32:
+			hasFloat32 = true
+		case sppb.TypeCode_FLOAT64:
+			hasFloat64 = true
+		default:
+			return nil
+		}
+	}
+
+	switch {
+	case hasFloat64:
+		return typector.Float64()
+	case hasFloat32 && (hasInt64 || hasNumeric):
+		return typector.Float64()
+	case hasFloat32:
+		return typector.Float32()
+	case hasNumeric:
+		return typector.Numeric()
+	default:
+		return typector.Int64()
+	}
+}
+
+func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {
+	coerced := make([]spanner.GenericColumnValue, 0, len(gcvs))
+	for _, gcv := range gcvs {
+		if isNullGCV(gcv) {
+			coerced = append(coerced, gcvctor.NullOf(elemType))
+			continue
+		}
+		if proto.Equal(gcv.Type, elemType) {
+			coerced = append(coerced, gcv)
+			continue
+		}
+		elem, err := coerceArrayElement(elemType, gcv)
+		if err != nil {
+			return nil, err
+		}
+		coerced = append(coerced, elem)
+	}
+	return coerced, nil
+}
+
+func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	switch elemType.GetCode() {
+	case sppb.TypeCode_NUMERIC:
+		if gcv.Type.GetCode() == sppb.TypeCode_INT64 {
+			v, err := int64FromGCV(gcv)
+			if err != nil {
+				return zeroGCV, err
+			}
+			return gcvctor.NumericValueChecked(big.NewRat(v, 1))
+		}
+	case sppb.TypeCode_FLOAT64:
+		return coerceArrayElementToFloat64(gcv)
+	}
+	return zeroGCV, fmt.Errorf("cannot coerce array element from %v to %v", gcv.Type.GetCode(), elemType.GetCode())
+}
+
+func coerceArrayElementToFloat64(gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	switch gcv.Type.GetCode() {
+	case sppb.TypeCode_INT64:
+		v, err := int64FromGCV(gcv)
+		if err != nil {
+			return zeroGCV, err
+		}
+		return gcvctor.Float64Value(float64(v)), nil
+	case sppb.TypeCode_FLOAT32:
+		v, err := float64FromGCV(gcv, 32)
+		if err != nil {
+			return zeroGCV, err
+		}
+		return gcvctor.Float64Value(v), nil
+	case sppb.TypeCode_NUMERIC:
+		v, err := stringFromGCV(gcv)
+		if err != nil {
+			return zeroGCV, err
+		}
+		n, ok := new(big.Rat).SetString(v)
+		if !ok {
+			return zeroGCV, fmt.Errorf("invalid NUMERIC wire value: %q", v)
+		}
+		f, _ := n.Float64()
+		return gcvctor.Float64Value(f), nil
+	default:
+		return zeroGCV, fmt.Errorf("cannot coerce array element from %v to FLOAT64", gcv.Type.GetCode())
+	}
 }
 
 func nameOrEmpty(f *ast.StructField) string {

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -280,8 +280,6 @@ func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 			coerced = append(coerced, gcv)
 			continue
 		}
-		// Unsupported coercions intentionally return an error to let
-		// arrayLiteralValueOf preserve the original permissive wire-value fallback.
 		elem, err := coerceArrayElement(elemType, gcv)
 		if err != nil {
 			return nil, err
@@ -292,6 +290,9 @@ func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 }
 
 func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	// This is not the full CAST matrix. It only models array literal coercions
+	// that are safe locally; unsupported cases return an error so the caller can
+	// preserve the pre-existing permissive wire-value fallback.
 	switch elemType.GetCode() {
 	case sppb.TypeCode_NUMERIC:
 		if gcv.Type.GetCode() == sppb.TypeCode_INT64 {

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -185,24 +185,49 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 	}
 
 	var first *sppb.Type
-	codes := make([]sppb.TypeCode, 0, len(exprs))
+	var hasInt64, hasNumeric, hasFloat32, hasFloat64, hasOther bool
 	for i, expr := range exprs {
 		if _, ok := unwrapParenExpr(expr).(*ast.NullLiteral); ok {
 			continue
 		}
+		typ := gcvs[i].Type
 		if first == nil {
-			first = gcvs[i].Type
+			first = typ
 		}
-		codes = append(codes, gcvs[i].Type.GetCode())
+		switch typ.GetCode() {
+		case sppb.TypeCode_INT64:
+			hasInt64 = true
+		case sppb.TypeCode_NUMERIC:
+			hasNumeric = true
+		case sppb.TypeCode_FLOAT32:
+			hasFloat32 = true
+		case sppb.TypeCode_FLOAT64:
+			hasFloat64 = true
+		default:
+			hasOther = true
+		}
 	}
 	if first == nil {
 		return typector.Int64()
 	}
-
-	if typ := commonNumericArrayElementType(codes); typ != nil {
-		return typ
+	if hasOther {
+		return first
 	}
-	return first
+
+	switch {
+	case hasFloat64:
+		return typector.Float64()
+	case hasFloat32 && (hasInt64 || hasNumeric):
+		return typector.Float64()
+	case hasFloat32:
+		return typector.Float32()
+	case hasNumeric:
+		return typector.Numeric()
+	case hasInt64:
+		return typector.Int64()
+	default:
+		return first
+	}
 }
 
 func unwrapParenExpr(expr ast.Expr) ast.Expr {
@@ -242,46 +267,6 @@ func arrayLiteralValueOf(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 	}
 
 	return gcvctor.ArrayValueOf(elemType, normalized...)
-}
-
-func commonNumericArrayElementType(codes []sppb.TypeCode) *sppb.Type {
-	if len(codes) == 0 {
-		return nil
-	}
-
-	hasInt64 := false
-	hasNumeric := false
-	hasFloat32 := false
-	hasFloat64 := false
-	for _, code := range codes {
-		switch code {
-		case sppb.TypeCode_INT64:
-			hasInt64 = true
-		case sppb.TypeCode_NUMERIC:
-			hasNumeric = true
-		case sppb.TypeCode_FLOAT32:
-			hasFloat32 = true
-		case sppb.TypeCode_FLOAT64:
-			hasFloat64 = true
-		default:
-			return nil
-		}
-	}
-
-	switch {
-	case hasFloat64:
-		return typector.Float64()
-	case hasFloat32 && (hasInt64 || hasNumeric):
-		return typector.Float64()
-	case hasFloat32:
-		return typector.Float32()
-	case hasNumeric:
-		return typector.Numeric()
-	case hasInt64:
-		return typector.Int64()
-	default:
-		return nil
-	}
 }
 
 func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -277,8 +277,10 @@ func commonNumericArrayElementType(codes []sppb.TypeCode) *sppb.Type {
 		return typector.Float32()
 	case hasNumeric:
 		return typector.Numeric()
-	default:
+	case hasInt64:
 		return typector.Int64()
+	default:
+		return nil
 	}
 }
 
@@ -293,6 +295,8 @@ func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 			coerced = append(coerced, gcv)
 			continue
 		}
+		// Unsupported coercions intentionally return an error to let
+		// arrayLiteralValueOf preserve the original permissive wire-value fallback.
 		elem, err := coerceArrayElement(elemType, gcv)
 		if err != nil {
 			return nil, err

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -312,10 +312,31 @@ func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (sp
 			}
 			return gcvctor.NumericValueChecked(big.NewRat(v, 1))
 		}
+	case sppb.TypeCode_FLOAT32:
+		return coerceArrayElementToFloat32(gcv)
 	case sppb.TypeCode_FLOAT64:
 		return coerceArrayElementToFloat64(gcv)
 	}
 	return zeroGCV, fmt.Errorf("cannot coerce array element from %v to %v", gcv.Type.GetCode(), elemType.GetCode())
+}
+
+func coerceArrayElementToFloat32(gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+	switch gcv.Type.GetCode() {
+	case sppb.TypeCode_INT64:
+		v, err := int64FromGCV(gcv)
+		if err != nil {
+			return zeroGCV, err
+		}
+		return float32ValueFromFloat64(float64(v))
+	case sppb.TypeCode_FLOAT64:
+		v, err := float64FromGCV(gcv, 64)
+		if err != nil {
+			return zeroGCV, err
+		}
+		return float32ValueFromFloat64(v)
+	default:
+		return zeroGCV, fmt.Errorf("cannot coerce array element from %v to FLOAT32", gcv.Type.GetCode())
+	}
 }
 
 func coerceArrayElementToFloat64(gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {

--- a/meme_to_sppb_value_test.go
+++ b/meme_to_sppb_value_test.go
@@ -160,17 +160,24 @@ func TestMemefishExprToGCV_EmptyArrayWithoutTypeReturnsError(t *testing.T) {
 	}
 }
 
-func TestMemefishExprToGCV_AllNullArrayWithoutTypeReturnsError(t *testing.T) {
-	_, err := memebridge.MemefishExprToGCV(&ast.ArrayLiteral{
+func TestMemefishExprToGCV_AllNullArrayWithoutTypeInfersInt64(t *testing.T) {
+	got, err := memebridge.MemefishExprToGCV(&ast.ArrayLiteral{
 		Values: []ast.Expr{
 			&ast.NullLiteral{},
 			&ast.NullLiteral{},
 		},
 	})
-	if err == nil {
-		t.Fatal("expected error for typeless all-null array literal")
+	if err != nil {
+		t.Fatalf("should not fail, but err: %v", err)
 	}
-	if !errors.Is(err, memebridge.ErrCannotInferArrayElementType) {
-		t.Fatalf("unexpected error: %v", err)
+	want := spanner.GenericColumnValue{
+		Type: typector.ElemCodeToArrayType(sppb.TypeCode_INT64),
+		Value: structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{
+			structpb.NewNullValue(),
+			structpb.NewNullValue(),
+		}}),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -1,7 +1,6 @@
 package memebridge_test
 
 import (
-	"errors"
 	"math"
 	"math/big"
 	"testing"
@@ -54,8 +53,29 @@ func TestParseExpr(t *testing.T) {
 		{`JSON '{"foo":"bar"}'`, must(gcvctor.JSONValue(map[string]string{"foo": "bar"}))},
 		{`[1, 2, 3]`, must(gcvctor.ArrayValue(gcvctor.Int64Value(1), gcvctor.Int64Value(2), gcvctor.Int64Value(3)))},
 		{`ARRAY<INT64>[1]`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.Int64Value(1)))},
+		{`[NULL, NULL]`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.NullOf(typector.Int64()), gcvctor.NullOf(typector.Int64())))},
 		{`[CAST(NULL AS STRING)]`, must(gcvctor.ArrayValueOf(typector.String(), gcvctor.NullOf(typector.String())))},
 		{`["foo", NULL]`, must(gcvctor.ArrayValueOf(typector.String(), gcvctor.StringValue("foo"), gcvctor.NullOf(typector.String())))},
+		{`[1, 2.5]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1), gcvctor.Float64Value(2.5)))},
+		{
+			`[1, NUMERIC "2.5"]`,
+			must(gcvctor.ArrayValueOf(
+				typector.Numeric(),
+				gcvctor.NumericValue(big.NewRat(1, 1)),
+				gcvctor.StringBasedValueFromCode(sppb.TypeCode_NUMERIC, "2.5"),
+			)),
+		},
+		{`[NUMERIC "1.5", 2.5]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1.5), gcvctor.Float64Value(2.5)))},
+		{`[CAST("1.5" AS FLOAT32), 2]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1.5), gcvctor.Float64Value(2)))},
+		{
+			`ARRAY<NUMERIC>[1, NULL]`,
+			must(gcvctor.ArrayValueOf(
+				typector.Numeric(),
+				gcvctor.NumericValue(big.NewRat(1, 1)),
+				gcvctor.NullOf(typector.Numeric()),
+			)),
+		},
+		{`ARRAY<FLOAT64>[1, NUMERIC "2.5"]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1), gcvctor.Float64Value(2.5)))},
 		{
 			`(1, "foo", 3.14)`,
 			must(gcvctor.StructValueOf(
@@ -219,13 +239,14 @@ func TestParseExpr_Numeric(t *testing.T) {
 	}
 }
 
-func TestParseExpr_AllParenthesizedNullArrayWithoutTypeReturnsError(t *testing.T) {
-	_, err := memebridge.ParseExpr("", "[(NULL)]")
-	if err == nil {
-		t.Fatal("expected error for typeless all-null array literal")
+func TestParseExpr_AllParenthesizedNullArrayInfersInt64(t *testing.T) {
+	got, err := memebridge.ParseExpr("", "[(NULL)]")
+	if err != nil {
+		t.Fatalf("should not fail, but err: %v", err)
 	}
-	if !errors.Is(err, memebridge.ErrCannotInferArrayElementType) {
-		t.Fatalf("unexpected error: %v", err)
+	want := must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.NullOf(typector.Int64())))
+	if diff := cmp.Diff(want, got, protocmp.Transform(), cmpopts.EquateNaNs()); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -76,6 +76,7 @@ func TestParseExpr(t *testing.T) {
 			)),
 		},
 		{`ARRAY<FLOAT64>[1, NUMERIC "2.5"]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1), gcvctor.Float64Value(2.5)))},
+		{`ARRAY<FLOAT32>[1, 2.5]`, must(gcvctor.ArrayValueOf(typector.Float32(), gcvctor.Float32Value(1), gcvctor.Float32Value(2.5)))},
 		{
 			`(1, "foo", 3.14)`,
 			must(gcvctor.StructValueOf(


### PR DESCRIPTION
Closes #14.

## Summary

- infer numeric common supertypes for array literals instead of always taking the first typed element
- coerce numeric array elements to inferred or explicit `NUMERIC`/`FLOAT64` element types
- infer all-`NULL` array literals as `ARRAY<INT64>` per GoogleSQL literal supertype rules

## Deferred follow-ups

- `SAFE_CAST`: #11
- remaining scalar `CAST` parity: #12
- common supertypes beyond array literals: #13

## Checks

- `make test`
- `make lint`