### PR TITLE
Support SAFE_CAST for local conversions

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -2,6 +2,7 @@ package memebridge
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -24,6 +25,8 @@ const (
 )
 
 var (
+	errUnsupportedCast = errors.New("unsupported cast")
+
 	numericScaleFactor = pow10Int(spanner.NumericScaleDigits)
 	maxScaledNumeric   = new(big.Int).Sub(pow10Int(spanner.NumericPrecisionDigits), big.NewInt(1))
 )
@@ -46,7 +49,14 @@ func memefishCastExprToGCV(cast *ast.CastExpr) (spanner.GenericColumnValue, erro
 		return gcvctor.NullOf(destType), nil
 	}
 
-	return castGCV(src, destType, cast.Expr.SQL())
+	gcv, err := castGCV(src, destType, cast.Expr.SQL())
+	if err == nil {
+		return gcv, nil
+	}
+	if cast.Safe && !errors.Is(err, errUnsupportedCast) {
+		return gcvctor.NullOf(destType), nil
+	}
+	return zeroGCV, err
 }
 
 func castGCV(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string) (spanner.GenericColumnValue, error) {
@@ -582,7 +592,7 @@ func formatSpannerFloat(v float64, bitSize int) string {
 }
 
 func unsupportedCastError(srcCode, destCode sppb.TypeCode, exprSQL string) error {
-	err := fmt.Errorf("unsupported cast from %v to %v", srcCode, destCode)
+	err := fmt.Errorf("%w from %v to %v", errUnsupportedCast, srcCode, destCode)
 	if exprSQL != "" {
 		return fmt.Errorf("%w: %s", err, exprSQL)
 	}

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -163,6 +163,17 @@ func TestParseExpr(t *testing.T) {
 		{`CAST("Infinity" AS FLOAT32)`, gcvctor.Float32Value(float32(math.Inf(1)))},
 		{`CAST("-Infinity" AS FLOAT32)`, gcvctor.Float32Value(float32(math.Inf(-1)))},
 		{`CAST("94a01a73-d90a-432d-a03f-5db58ea8058f" AS UUID)`, gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, `94a01a73-d90a-432d-a03f-5db58ea8058f`)},
+		{`SAFE_CAST("42" AS INT64)`, gcvctor.Int64Value(42)},
+		{`SAFE_CAST("12x" AS INT64)`, gcvctor.NullOf(typector.Int64())},
+		{`SAFE_CAST("maybe" AS BOOL)`, gcvctor.NullOf(typector.Bool())},
+		{`SAFE_CAST("not-a-number" AS NUMERIC)`, gcvctor.NullOf(typector.Numeric())},
+		{`SAFE_CAST(1e50 AS FLOAT32)`, gcvctor.NullOf(typector.Float32())},
+		{`SAFE_CAST(CAST("NaN" AS FLOAT64) AS INT64)`, gcvctor.NullOf(typector.Int64())},
+		{`SAFE_CAST(b"\xff" AS STRING)`, gcvctor.NullOf(typector.String())},
+		{`SAFE_CAST("not-a-date" AS DATE)`, gcvctor.NullOf(typector.Date())},
+		{`SAFE_CAST("not-a-timestamp" AS TIMESTAMP)`, gcvctor.NullOf(typector.Timestamp())},
+		{`SAFE_CAST("not-a-uuid" AS UUID)`, gcvctor.NullOf(typector.UUID())},
+		{`SAFE_CAST("not-an-interval" AS INTERVAL)`, gcvctor.NullOf(typector.Interval())},
 
 		{"PENDING_COMMIT_TIMESTAMP()", gcvctor.StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, "spanner.commit_timestamp()")},
 
@@ -278,6 +289,8 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`CAST("not-an-interval" AS INTERVAL)`,
 		`CAST(CAST("nan" AS FLOAT64) AS INT64)`,
 		`CAST(b"\xff" AS STRING)`,
+		`SAFE_CAST(TRUE AS BYTES)`,
+		`SAFE_CAST([1] AS INT64)`,
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- add SAFE_CAST support for locally evaluable casts
- return typed NULL for runtime conversion failures
- keep impossible unsupported casts as errors
- add regression coverage for invalid bool, numeric, UTF-8, temporal, UUID, and INTERVAL conversions

## Issue

Closes #11

## Pre-PR review

- Opus 4.7 branch review: no blocking findings
- GPT-5.5 branch review: no blocking findings

## Checks

- make test
- make lint