### PR TITLE
Support typed struct field coercion

### DIFF
--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -219,7 +219,10 @@ func coerceStringLiteralToTypedStructField(
 		return gcvctor.TimestampStringValue(lit.Value)
 	case sppb.TypeCode_UUID:
 		u, err := uuid.Parse(lit.Value)
-		if err != nil || !strings.EqualFold(u.String(), lit.Value) {
+		if err != nil {
+			return zeroGCV, fmt.Errorf("invalid UUID literal for typed struct field %q: %w", lit.Value, err)
+		}
+		if !strings.EqualFold(u.String(), lit.Value) {
 			return zeroGCV, fmt.Errorf("invalid UUID literal for typed struct field: %q", lit.Value)
 		}
 		return gcvctor.UUIDValue(u), nil
@@ -427,9 +430,6 @@ func arrayLiteralValueOf(
 		if coerceErr == nil {
 			return gcvctor.ArrayValueOf(elemType, coerced...)
 		}
-		if !allowFallback {
-			return zeroGCV, coerceErr
-		}
 
 		// Preserve the current permissive behavior for array literals whose
 		// element values do not all match elemType. This intentionally keeps the
@@ -459,7 +459,13 @@ func coerceArrayElements(
 			if !isUntypedNullLiteral(exprs[i]) &&
 				!proto.Equal(gcv.Type, elemType) &&
 				!canCoerceArrayElementType(elemType, gcv.Type) {
-				return nil, fmt.Errorf("cannot coerce array element from %v to %v", gcv.Type.GetCode(), elemType.GetCode())
+				return nil, fmt.Errorf(
+					"cannot coerce array element %d (%s) from %v to %v",
+					i,
+					exprs[i].SQL(),
+					gcv.Type.GetCode(),
+					elemType.GetCode(),
+				)
 			}
 			coerced = append(coerced, gcvctor.NullOf(elemType))
 			continue
@@ -471,14 +477,14 @@ func coerceArrayElements(
 		if isStringLiteralCoercion(elemType, gcv.Type, exprs[i]) {
 			elem, err := coerceStringLiteralToTypedStructField(elemType, exprs[i])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("cannot coerce array element %d (%s): %w", i, exprs[i].SQL(), err)
 			}
 			coerced = append(coerced, elem)
 			continue
 		}
 		elem, err := coerceArrayElement(elemType, gcv)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot coerce array element %d (%s): %w", i, exprs[i].SQL(), err)
 		}
 		coerced = append(coerced, elem)
 	}

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -90,8 +90,8 @@ func typedStructLiteralToGCV(expr *ast.TypedStructLiteral) (spanner.GenericColum
 		return zeroGCV, fmt.Errorf("typed struct literal has %d fields but %d values", len(expr.Fields), len(expr.Values))
 	}
 
-	names := make([]string, 0, len(expr.Fields))
-	gcvs := make([]spanner.GenericColumnValue, 0, len(expr.Values))
+	names := make([]string, len(expr.Fields))
+	gcvs := make([]spanner.GenericColumnValue, len(expr.Values))
 	for i, field := range expr.Fields {
 		if field == nil {
 			return zeroGCV, fmt.Errorf("typed struct literal has nil field at index %d", i)
@@ -108,8 +108,8 @@ func typedStructLiteralToGCV(expr *ast.TypedStructLiteral) (spanner.GenericColum
 		if err != nil {
 			return zeroGCV, err
 		}
-		names = append(names, nameOrEmpty(field))
-		gcvs = append(gcvs, coerced)
+		names[i] = fieldNameOrEmpty(field)
+		gcvs[i] = coerced
 	}
 	return gcvctor.StructValueOf(names, gcvs)
 }
@@ -480,33 +480,33 @@ func coerceArrayElementsStrict(
 	exprs []ast.Expr,
 	gcvs []spanner.GenericColumnValue,
 ) ([]spanner.GenericColumnValue, error) {
-	coerced := make([]spanner.GenericColumnValue, 0, len(gcvs))
+	coerced := make([]spanner.GenericColumnValue, len(gcvs))
 	for i, gcv := range gcvs {
 		elem, err := coerceTypedStructField(elemType, gcv, exprs[i])
 		if err != nil {
 			return nil, fmt.Errorf("cannot coerce array element %d (%s): %w", i, exprs[i].SQL(), err)
 		}
-		coerced = append(coerced, elem)
+		coerced[i] = elem
 	}
 	return coerced, nil
 }
 
 func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {
-	coerced := make([]spanner.GenericColumnValue, 0, len(gcvs))
-	for _, gcv := range gcvs {
+	coerced := make([]spanner.GenericColumnValue, len(gcvs))
+	for i, gcv := range gcvs {
 		if isNullGCV(gcv) {
-			coerced = append(coerced, gcvctor.NullOf(elemType))
+			coerced[i] = gcvctor.NullOf(elemType)
 			continue
 		}
 		if proto.Equal(gcv.Type, elemType) {
-			coerced = append(coerced, gcv)
+			coerced[i] = gcv
 			continue
 		}
 		elem, err := coerceArrayElement(elemType, gcv)
 		if err != nil {
 			return nil, err
 		}
-		coerced = append(coerced, elem)
+		coerced[i] = elem
 	}
 	return coerced, nil
 }
@@ -581,13 +581,6 @@ func coerceArrayElementToFloat64(gcv spanner.GenericColumnValue) (spanner.Generi
 	default:
 		return zeroGCV, fmt.Errorf("cannot coerce array element from %v to FLOAT64", gcv.Type.GetCode())
 	}
-}
-
-func nameOrEmpty(f *ast.StructField) string {
-	if f != nil && f.Ident != nil {
-		return f.Ident.Name
-	}
-	return ""
 }
 
 func gcvToValue(gcv spanner.GenericColumnValue) *structpb.Value {

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -185,13 +185,6 @@ func canCoerceTypedNullToField(fieldType, valueType *sppb.Type) bool {
 	switch fieldType.GetCode() {
 	case sppb.TypeCode_NUMERIC:
 		return valueType.GetCode() == sppb.TypeCode_INT64
-	case sppb.TypeCode_FLOAT32:
-		switch valueType.GetCode() {
-		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT64:
-			return true
-		default:
-			return false
-		}
 	case sppb.TypeCode_FLOAT64:
 		switch valueType.GetCode() {
 		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT32, sppb.TypeCode_NUMERIC:

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -135,7 +135,10 @@ func coerceTypedStructField(
 	if isNullGCV(gcv) && isUntypedNullLiteral(expr) {
 		return gcvctor.NullOf(fieldType), nil
 	}
-	if !canCoerceTypedStructField(fieldType, gcv.Type, expr) {
+	if isNullGCV(gcv) {
+		if canCoerceTypedNullToField(fieldType, gcv.Type) {
+			return gcvctor.NullOf(fieldType), nil
+		}
 		return zeroGCV, fmt.Errorf(
 			"cannot coerce typed struct field from %v to %v: %s",
 			gcv.Type.GetCode(),
@@ -143,8 +146,13 @@ func coerceTypedStructField(
 			expr.SQL(),
 		)
 	}
-	if isNullGCV(gcv) {
-		return gcvctor.NullOf(fieldType), nil
+	if !canCoerceTypedStructField(fieldType, gcv.Type, expr) {
+		return zeroGCV, fmt.Errorf(
+			"cannot coerce typed struct field from %v to %v: %s",
+			gcv.Type.GetCode(),
+			fieldType.GetCode(),
+			expr.SQL(),
+		)
 	}
 	if isStringLiteralCoercion(fieldType, gcv.Type, expr) {
 		return coerceStringLiteralToTypedStructField(fieldType, expr)
@@ -168,6 +176,29 @@ func canCoerceTypedStructField(fieldType, valueType *sppb.Type, expr ast.Expr) b
 		}
 	case sppb.TypeCode_DATE, sppb.TypeCode_TIMESTAMP, sppb.TypeCode_UUID, sppb.TypeCode_INTERVAL:
 		return valueType.GetCode() == sppb.TypeCode_STRING && isStringLiteral(expr)
+	default:
+		return false
+	}
+}
+
+func canCoerceTypedNullToField(fieldType, valueType *sppb.Type) bool {
+	switch fieldType.GetCode() {
+	case sppb.TypeCode_NUMERIC:
+		return valueType.GetCode() == sppb.TypeCode_INT64
+	case sppb.TypeCode_FLOAT32:
+		switch valueType.GetCode() {
+		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT64:
+			return true
+		default:
+			return false
+		}
+	case sppb.TypeCode_FLOAT64:
+		switch valueType.GetCode() {
+		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT32, sppb.TypeCode_NUMERIC:
+			return true
+		default:
+			return false
+		}
 	default:
 		return false
 	}
@@ -413,7 +444,7 @@ func arrayLiteralValueOf(
 	allowFallback bool,
 ) (spanner.GenericColumnValue, error) {
 	if !allowFallback {
-		coerced, err := coerceArrayElements(elemType, exprs, gcvs)
+		coerced, err := coerceArrayElementsStrict(elemType, exprs, gcvs)
 		if err != nil {
 			return zeroGCV, err
 		}
@@ -426,7 +457,7 @@ func arrayLiteralValueOf(
 			return zeroGCV, err
 		}
 
-		coerced, coerceErr := coerceArrayElements(elemType, exprs, gcvs)
+		coerced, coerceErr := coerceArrayElements(elemType, gcvs)
 		if coerceErr == nil {
 			return gcvctor.ArrayValueOf(elemType, coerced...)
 		}
@@ -448,41 +479,14 @@ func arrayLiteralValueOf(
 	return gcvctor.ArrayValueOf(elemType, normalized...)
 }
 
-func coerceArrayElements(
+func coerceArrayElementsStrict(
 	elemType *sppb.Type,
 	exprs []ast.Expr,
 	gcvs []spanner.GenericColumnValue,
 ) ([]spanner.GenericColumnValue, error) {
 	coerced := make([]spanner.GenericColumnValue, 0, len(gcvs))
 	for i, gcv := range gcvs {
-		if isNullGCV(gcv) {
-			if !isUntypedNullLiteral(exprs[i]) &&
-				!proto.Equal(gcv.Type, elemType) &&
-				!canCoerceArrayElementType(elemType, gcv.Type) {
-				return nil, fmt.Errorf(
-					"cannot coerce array element %d (%s) from %v to %v",
-					i,
-					exprs[i].SQL(),
-					gcv.Type.GetCode(),
-					elemType.GetCode(),
-				)
-			}
-			coerced = append(coerced, gcvctor.NullOf(elemType))
-			continue
-		}
-		if proto.Equal(gcv.Type, elemType) {
-			coerced = append(coerced, gcv)
-			continue
-		}
-		if isStringLiteralCoercion(elemType, gcv.Type, exprs[i]) {
-			elem, err := coerceStringLiteralToTypedStructField(elemType, exprs[i])
-			if err != nil {
-				return nil, fmt.Errorf("cannot coerce array element %d (%s): %w", i, exprs[i].SQL(), err)
-			}
-			coerced = append(coerced, elem)
-			continue
-		}
-		elem, err := coerceArrayElement(elemType, gcv)
+		elem, err := coerceTypedStructField(elemType, gcv, exprs[i])
 		if err != nil {
 			return nil, fmt.Errorf("cannot coerce array element %d (%s): %w", i, exprs[i].SQL(), err)
 		}
@@ -491,27 +495,24 @@ func coerceArrayElements(
 	return coerced, nil
 }
 
-func canCoerceArrayElementType(elemType, valueType *sppb.Type) bool {
-	switch elemType.GetCode() {
-	case sppb.TypeCode_NUMERIC:
-		return valueType.GetCode() == sppb.TypeCode_INT64
-	case sppb.TypeCode_FLOAT32:
-		switch valueType.GetCode() {
-		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT64:
-			return true
-		default:
-			return false
+func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {
+	coerced := make([]spanner.GenericColumnValue, 0, len(gcvs))
+	for _, gcv := range gcvs {
+		if isNullGCV(gcv) {
+			coerced = append(coerced, gcvctor.NullOf(elemType))
+			continue
 		}
-	case sppb.TypeCode_FLOAT64:
-		switch valueType.GetCode() {
-		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT32, sppb.TypeCode_NUMERIC:
-			return true
-		default:
-			return false
+		if proto.Equal(gcv.Type, elemType) {
+			coerced = append(coerced, gcv)
+			continue
 		}
-	default:
-		return false
+		elem, err := coerceArrayElement(elemType, gcv)
+		if err != nil {
+			return nil, err
+		}
+		coerced = append(coerced, elem)
 	}
+	return coerced, nil
 }
 
 func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/apstndb/spantype/typector"
 	"github.com/apstndb/spanvalue/gcvctor"
@@ -15,6 +16,7 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -60,7 +62,7 @@ func astStructLiteralsToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 			names = append(names, name)
 			gcvs = append(gcvs, gcv)
 		}
-	case *ast.TupleStructLiteral, *ast.TypedStructLiteral:
+	case *ast.TupleStructLiteral:
 		astValues, err := extractValues(e)
 		if err != nil {
 			return zeroGCV, errors.New("invalid state")
@@ -73,19 +75,159 @@ func astStructLiteralsToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 			return zeroGCV, err
 		}
 
-		switch e := expr.(type) {
-		case *ast.TupleStructLiteral:
-			names = slices.Repeat([]string{""}, len(gcvs))
-		case *ast.TypedStructLiteral:
-			names = lo.Map(e.Fields, func(f *ast.StructField, _ int) string {
-				return nameOrEmpty(f)
-			})
-		}
+		names = slices.Repeat([]string{""}, len(gcvs))
+	case *ast.TypedStructLiteral:
+		return typedStructLiteralToGCV(e)
 	default:
 		return zeroGCV, fmt.Errorf("expr is not struct literal: %v", e)
 	}
 
 	return gcvctor.StructValueOf(names, gcvs)
+}
+
+func typedStructLiteralToGCV(expr *ast.TypedStructLiteral) (spanner.GenericColumnValue, error) {
+	if len(expr.Fields) != len(expr.Values) {
+		return zeroGCV, fmt.Errorf("typed struct literal has %d fields but %d values", len(expr.Fields), len(expr.Values))
+	}
+
+	names := make([]string, 0, len(expr.Fields))
+	gcvs := make([]spanner.GenericColumnValue, 0, len(expr.Values))
+	for i, field := range expr.Fields {
+		if field == nil {
+			return zeroGCV, fmt.Errorf("typed struct literal has nil field at index %d", i)
+		}
+		fieldType, err := MemefishTypeToSpannerpbType(field.Type)
+		if err != nil {
+			return zeroGCV, err
+		}
+		gcv, err := typedStructFieldExprToGCV(fieldType, expr.Values[i])
+		if err != nil {
+			return zeroGCV, err
+		}
+		coerced, err := coerceTypedStructField(fieldType, gcv, expr.Values[i])
+		if err != nil {
+			return zeroGCV, err
+		}
+		names = append(names, nameOrEmpty(field))
+		gcvs = append(gcvs, coerced)
+	}
+	return gcvctor.StructValueOf(names, gcvs)
+}
+
+func typedStructFieldExprToGCV(fieldType *sppb.Type, expr ast.Expr) (spanner.GenericColumnValue, error) {
+	if fieldType.GetCode() == sppb.TypeCode_ARRAY {
+		array, ok := unwrapParenExpr(expr).(*ast.ArrayLiteral)
+		if ok {
+			return arrayLiteralToGCVStrict(array, fieldType.GetArrayElementType())
+		}
+	}
+	return MemefishExprToGCV(expr)
+}
+
+func coerceTypedStructField(
+	fieldType *sppb.Type,
+	gcv spanner.GenericColumnValue,
+	expr ast.Expr,
+) (spanner.GenericColumnValue, error) {
+	if proto.Equal(gcv.Type, fieldType) {
+		return spanner.GenericColumnValue{Type: fieldType, Value: gcv.Value}, nil
+	}
+	if isNullGCV(gcv) && isUntypedNullLiteral(expr) {
+		return gcvctor.NullOf(fieldType), nil
+	}
+	if !canCoerceTypedStructField(fieldType, gcv.Type, expr) {
+		return zeroGCV, fmt.Errorf(
+			"cannot coerce typed struct field from %v to %v: %s",
+			gcv.Type.GetCode(),
+			fieldType.GetCode(),
+			expr.SQL(),
+		)
+	}
+	if isNullGCV(gcv) {
+		return gcvctor.NullOf(fieldType), nil
+	}
+	if isStringLiteralCoercion(fieldType, gcv.Type, expr) {
+		return coerceStringLiteralToTypedStructField(fieldType, expr)
+	}
+	return castGCV(gcv, fieldType, expr.SQL())
+}
+
+func canCoerceTypedStructField(fieldType, valueType *sppb.Type, expr ast.Expr) bool {
+	switch fieldType.GetCode() {
+	case sppb.TypeCode_NUMERIC:
+		return valueType.GetCode() == sppb.TypeCode_INT64 ||
+			isNumericLiteralForType(expr, valueType, sppb.TypeCode_NUMERIC)
+	case sppb.TypeCode_FLOAT32:
+		return isNumericLiteralForType(expr, valueType, sppb.TypeCode_FLOAT32)
+	case sppb.TypeCode_FLOAT64:
+		switch valueType.GetCode() {
+		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT32, sppb.TypeCode_NUMERIC:
+			return true
+		default:
+			return false
+		}
+	case sppb.TypeCode_DATE, sppb.TypeCode_TIMESTAMP, sppb.TypeCode_UUID, sppb.TypeCode_INTERVAL:
+		return valueType.GetCode() == sppb.TypeCode_STRING && isStringLiteral(expr)
+	default:
+		return false
+	}
+}
+
+func isUntypedNullLiteral(expr ast.Expr) bool {
+	_, ok := unwrapParenExpr(expr).(*ast.NullLiteral)
+	return ok
+}
+
+func isNumericLiteralForType(expr ast.Expr, typ *sppb.Type, target sppb.TypeCode) bool {
+	switch unwrapParenExpr(expr).(type) {
+	case *ast.IntLiteral:
+		return target == sppb.TypeCode_FLOAT32 || target == sppb.TypeCode_NUMERIC
+	case *ast.FloatLiteral:
+		return typ.GetCode() == sppb.TypeCode_FLOAT64 &&
+			(target == sppb.TypeCode_FLOAT32 || target == sppb.TypeCode_NUMERIC)
+	default:
+		return false
+	}
+}
+
+func isStringLiteral(expr ast.Expr) bool {
+	_, ok := unwrapParenExpr(expr).(*ast.StringLiteral)
+	return ok
+}
+
+func isStringLiteralCoercion(fieldType, valueType *sppb.Type, expr ast.Expr) bool {
+	switch fieldType.GetCode() {
+	case sppb.TypeCode_DATE, sppb.TypeCode_TIMESTAMP, sppb.TypeCode_UUID, sppb.TypeCode_INTERVAL:
+		return valueType.GetCode() == sppb.TypeCode_STRING && isStringLiteral(expr)
+	default:
+		return false
+	}
+}
+
+func coerceStringLiteralToTypedStructField(
+	fieldType *sppb.Type,
+	expr ast.Expr,
+) (spanner.GenericColumnValue, error) {
+	lit, ok := unwrapParenExpr(expr).(*ast.StringLiteral)
+	if !ok {
+		return zeroGCV, fmt.Errorf("expected string literal for typed struct field coercion: %s", expr.SQL())
+	}
+	switch fieldType.GetCode() {
+	case sppb.TypeCode_DATE:
+		return gcvctor.DateStringValue(lit.Value)
+	case sppb.TypeCode_TIMESTAMP:
+		return gcvctor.TimestampStringValue(lit.Value)
+	case sppb.TypeCode_UUID:
+		u, err := uuid.Parse(lit.Value)
+		if err != nil || !strings.EqualFold(u.String(), lit.Value) {
+			return zeroGCV, fmt.Errorf("invalid UUID literal for typed struct field: %q", lit.Value)
+		}
+		return gcvctor.UUIDValue(u), nil
+	case sppb.TypeCode_INTERVAL:
+		return gcvctor.IntervalStringValue(lit.Value)
+	default:
+		return zeroGCV, fmt.Errorf("cannot coerce string literal to typed struct field type %v", fieldType.GetCode())
+	}
 }
 
 func extractValues(expr ast.Expr) ([]ast.Expr, error) {
@@ -131,31 +273,7 @@ func MemefishExprToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 	case *ast.JSONLiteral:
 		return gcvctor.StringBasedValueFromCode(sppb.TypeCode_JSON, e.Value.Value), nil
 	case *ast.ArrayLiteral:
-		gcvs, err := lo.MapErr(e.Values, func(expr ast.Expr, _ int) (spanner.GenericColumnValue, error) {
-			return MemefishExprToGCV(expr)
-		})
-		if err != nil {
-			return zeroGCV, err
-		}
-
-		// An explicit ARRAY<T> annotation takes precedence; otherwise infer a
-		// local common supertype from the literal elements.
-		var typ *sppb.Type
-		if e.Type != nil {
-			// memefish stores the explicit type from ARRAY<T>[...] as the element type T,
-			// so MemefishTypeToSpannerpbType already returns the correct elemType here.
-			typ, err = MemefishTypeToSpannerpbType(e.Type)
-			if err != nil {
-				return zeroGCV, err
-			}
-		} else {
-			typ = inferArrayElementType(e.Values, gcvs)
-		}
-		if typ == nil {
-			return zeroGCV, ErrCannotInferArrayElementType
-		}
-
-		return arrayLiteralValueOf(typ, gcvs)
+		return arrayLiteralToGCV(e, nil)
 	case *ast.TypelessStructLiteral,
 		*ast.TupleStructLiteral,
 		*ast.TypedStructLiteral:
@@ -175,6 +293,51 @@ func MemefishExprToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 		// break
 	}
 	return zeroGCV, fmt.Errorf("not implemented: %s", expr.SQL())
+}
+
+func arrayLiteralToGCV(
+	expr *ast.ArrayLiteral,
+	expectedElemType *sppb.Type,
+) (spanner.GenericColumnValue, error) {
+	return arrayLiteralToGCVWithFallback(expr, expectedElemType, true)
+}
+
+func arrayLiteralToGCVStrict(
+	expr *ast.ArrayLiteral,
+	expectedElemType *sppb.Type,
+) (spanner.GenericColumnValue, error) {
+	return arrayLiteralToGCVWithFallback(expr, expectedElemType, false)
+}
+
+func arrayLiteralToGCVWithFallback(
+	expr *ast.ArrayLiteral,
+	expectedElemType *sppb.Type,
+	allowFallback bool,
+) (spanner.GenericColumnValue, error) {
+	gcvs, err := lo.MapErr(expr.Values, func(value ast.Expr, _ int) (spanner.GenericColumnValue, error) {
+		return MemefishExprToGCV(value)
+	})
+	if err != nil {
+		return zeroGCV, err
+	}
+
+	// An explicit ARRAY<T> annotation takes precedence; otherwise use a local
+	// expected element type if one is available, then fall back to inference.
+	elemType := expectedElemType
+	if expr.Type != nil {
+		elemType, err = MemefishTypeToSpannerpbType(expr.Type)
+		if err != nil {
+			return zeroGCV, err
+		}
+	}
+	if elemType == nil {
+		elemType = inferArrayElementType(expr.Values, gcvs)
+	}
+	if elemType == nil {
+		return zeroGCV, ErrCannotInferArrayElementType
+	}
+
+	return arrayLiteralValueOf(elemType, expr.Values, gcvs, allowFallback)
 }
 
 func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) *sppb.Type {
@@ -240,16 +403,32 @@ func unwrapParenExpr(expr ast.Expr) ast.Expr {
 	}
 }
 
-func arrayLiteralValueOf(elemType *sppb.Type, gcvs []spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {
+func arrayLiteralValueOf(
+	elemType *sppb.Type,
+	exprs []ast.Expr,
+	gcvs []spanner.GenericColumnValue,
+	allowFallback bool,
+) (spanner.GenericColumnValue, error) {
+	if !allowFallback {
+		coerced, err := coerceArrayElements(elemType, exprs, gcvs)
+		if err != nil {
+			return zeroGCV, err
+		}
+		return gcvctor.ArrayValueOf(elemType, coerced...)
+	}
+
 	normalized, err := gcvctor.NormalizeArrayElements(elemType, gcvs...)
 	if err != nil {
 		if !errors.Is(err, gcvctor.ErrTypeMismatch) {
 			return zeroGCV, err
 		}
 
-		coerced, coerceErr := coerceArrayElements(elemType, gcvs)
+		coerced, coerceErr := coerceArrayElements(elemType, exprs, gcvs)
 		if coerceErr == nil {
 			return gcvctor.ArrayValueOf(elemType, coerced...)
+		}
+		if !allowFallback {
+			return zeroGCV, coerceErr
 		}
 
 		// Preserve the current permissive behavior for array literals whose
@@ -269,15 +448,32 @@ func arrayLiteralValueOf(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 	return gcvctor.ArrayValueOf(elemType, normalized...)
 }
 
-func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue) ([]spanner.GenericColumnValue, error) {
+func coerceArrayElements(
+	elemType *sppb.Type,
+	exprs []ast.Expr,
+	gcvs []spanner.GenericColumnValue,
+) ([]spanner.GenericColumnValue, error) {
 	coerced := make([]spanner.GenericColumnValue, 0, len(gcvs))
-	for _, gcv := range gcvs {
+	for i, gcv := range gcvs {
 		if isNullGCV(gcv) {
+			if !isUntypedNullLiteral(exprs[i]) &&
+				!proto.Equal(gcv.Type, elemType) &&
+				!canCoerceArrayElementType(elemType, gcv.Type) {
+				return nil, fmt.Errorf("cannot coerce array element from %v to %v", gcv.Type.GetCode(), elemType.GetCode())
+			}
 			coerced = append(coerced, gcvctor.NullOf(elemType))
 			continue
 		}
 		if proto.Equal(gcv.Type, elemType) {
 			coerced = append(coerced, gcv)
+			continue
+		}
+		if isStringLiteralCoercion(elemType, gcv.Type, exprs[i]) {
+			elem, err := coerceStringLiteralToTypedStructField(elemType, exprs[i])
+			if err != nil {
+				return nil, err
+			}
+			coerced = append(coerced, elem)
 			continue
 		}
 		elem, err := coerceArrayElement(elemType, gcv)
@@ -287,6 +483,29 @@ func coerceArrayElements(elemType *sppb.Type, gcvs []spanner.GenericColumnValue)
 		coerced = append(coerced, elem)
 	}
 	return coerced, nil
+}
+
+func canCoerceArrayElementType(elemType, valueType *sppb.Type) bool {
+	switch elemType.GetCode() {
+	case sppb.TypeCode_NUMERIC:
+		return valueType.GetCode() == sppb.TypeCode_INT64
+	case sppb.TypeCode_FLOAT32:
+		switch valueType.GetCode() {
+		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT64:
+			return true
+		default:
+			return false
+		}
+	case sppb.TypeCode_FLOAT64:
+		switch valueType.GetCode() {
+		case sppb.TypeCode_INT64, sppb.TypeCode_FLOAT32, sppb.TypeCode_NUMERIC:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
 }
 
 func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (spanner.GenericColumnValue, error) {

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -236,6 +236,9 @@ func coerceStringLiteralToTypedStructField(
 	if !ok {
 		return zeroGCV, fmt.Errorf("expected string literal for typed struct field coercion: %s", expr.SQL())
 	}
+	// GoogleSQL literal coercion is stricter than CAST parsing here. Do not
+	// trim whitespace; only canonical literal text should satisfy an expected
+	// DATE, TIMESTAMP, UUID, or INTERVAL field type.
 	switch fieldType.GetCode() {
 	case sppb.TypeCode_DATE:
 		return gcvctor.DateStringValue(lit.Value)

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -136,6 +136,13 @@ func TestParseExpr(t *testing.T) {
 			)),
 		},
 		{
+			`STRUCT<f32 FLOAT32>(CAST(NULL AS INT64))`,
+			must(gcvctor.StructValueOf(
+				[]string{"f32"},
+				[]spanner.GenericColumnValue{gcvctor.NullOf(typector.Float32())},
+			)),
+		},
+		{
 			`STRUCT<a ARRAY<NUMERIC>>([1, NULL])`,
 			must(gcvctor.StructValueOf(
 				[]string{"a"},
@@ -169,6 +176,18 @@ func TestParseExpr(t *testing.T) {
 					must(gcvctor.ArrayValueOf(
 						typector.Date(),
 						gcvctor.DateValue(civil.Date{Year: 1970, Month: time.January, Day: 1}),
+					)),
+				},
+			)),
+		},
+		{
+			`STRUCT<a ARRAY<FLOAT32>>([CAST(NULL AS INT64)])`,
+			must(gcvctor.StructValueOf(
+				[]string{"a"},
+				[]spanner.GenericColumnValue{
+					must(gcvctor.ArrayValueOf(
+						typector.Float32(),
+						gcvctor.NullOf(typector.Float32()),
 					)),
 				},
 			)),
@@ -375,6 +394,7 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`STRUCT<a ARRAY<BYTES>>(["foo"])`,
 		`STRUCT<a ARRAY<DATE>>(["not-a-date"])`,
 		`STRUCT<a ARRAY<INT64>>([CAST(NULL AS STRING)])`,
+		`STRUCT<a ARRAY<FLOAT32>>([CAST(1 AS FLOAT64)])`,
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -98,6 +98,81 @@ func TestParseExpr(t *testing.T) {
 				[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.StringValue("foo"), gcvctor.Float64Value(3.14)},
 			)),
 		},
+		{
+			`STRUCT<n NUMERIC, f FLOAT64, f32 FLOAT32>(1, NUMERIC "2.5", 3.5)`,
+			must(gcvctor.StructValueOf(
+				[]string{"n", "f", "f32"},
+				[]spanner.GenericColumnValue{
+					gcvctor.NumericValue(big.NewRat(1, 1)),
+					gcvctor.Float64Value(2.5),
+					gcvctor.Float32Value(3.5),
+				},
+			)),
+		},
+		{
+			`STRUCT<d DATE, ts TIMESTAMP, u UUID, i INTERVAL>("1970-01-01", "1970-01-01T00:00:00Z", "94a01a73-d90a-432d-a03f-5db58ea8058f", "P1Y")`,
+			must(gcvctor.StructValueOf(
+				[]string{"d", "ts", "u", "i"},
+				[]spanner.GenericColumnValue{
+					gcvctor.DateValue(civil.Date{Year: 1970, Month: time.January, Day: 1}),
+					gcvctor.TimestampValue(time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)),
+					gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, "94a01a73-d90a-432d-a03f-5db58ea8058f"),
+					gcvctor.StringBasedValueFromCode(sppb.TypeCode_INTERVAL, "P1Y"),
+				},
+			)),
+		},
+		{
+			`STRUCT<s STRING>(NULL)`,
+			must(gcvctor.StructValueOf(
+				[]string{"s"},
+				[]spanner.GenericColumnValue{gcvctor.NullOf(typector.String())},
+			)),
+		},
+		{
+			`STRUCT<n NUMERIC>(CAST(NULL AS INT64))`,
+			must(gcvctor.StructValueOf(
+				[]string{"n"},
+				[]spanner.GenericColumnValue{gcvctor.NullOf(typector.Numeric())},
+			)),
+		},
+		{
+			`STRUCT<a ARRAY<NUMERIC>>([1, NULL])`,
+			must(gcvctor.StructValueOf(
+				[]string{"a"},
+				[]spanner.GenericColumnValue{
+					must(gcvctor.ArrayValueOf(
+						typector.Numeric(),
+						gcvctor.NumericValue(big.NewRat(1, 1)),
+						gcvctor.NullOf(typector.Numeric()),
+					)),
+				},
+			)),
+		},
+		{
+			`STRUCT<a ARRAY<FLOAT64>>([1, NUMERIC "2.5"])`,
+			must(gcvctor.StructValueOf(
+				[]string{"a"},
+				[]spanner.GenericColumnValue{
+					must(gcvctor.ArrayValueOf(
+						typector.Float64(),
+						gcvctor.Float64Value(1),
+						gcvctor.Float64Value(2.5),
+					)),
+				},
+			)),
+		},
+		{
+			`STRUCT<a ARRAY<DATE>>(["1970-01-01"])`,
+			must(gcvctor.StructValueOf(
+				[]string{"a"},
+				[]spanner.GenericColumnValue{
+					must(gcvctor.ArrayValueOf(
+						typector.Date(),
+						gcvctor.DateValue(civil.Date{Year: 1970, Month: time.January, Day: 1}),
+					)),
+				},
+			)),
+		},
 		{"(1)", gcvctor.Int64Value(1)},
 		{`CAST(TRUE AS INT64)`, gcvctor.Int64Value(1)},
 		{`CAST(FALSE AS STRING)`, gcvctor.StringValue("false")},
@@ -291,6 +366,15 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`CAST(b"\xff" AS STRING)`,
 		`SAFE_CAST(TRUE AS BYTES)`,
 		`SAFE_CAST([1] AS INT64)`,
+		`STRUCT<i INT64>("1")`,
+		`STRUCT<b BYTES>("foo")`,
+		`STRUCT<i INT64>(CAST(NULL AS STRING))`,
+		`STRUCT<d DATE>(" 1970-01-01 ")`,
+		`STRUCT<u UUID>(" 94a01a73-d90a-432d-a03f-5db58ea8058f ")`,
+		`STRUCT<a ARRAY<INT64>>(["1"])`,
+		`STRUCT<a ARRAY<BYTES>>(["foo"])`,
+		`STRUCT<a ARRAY<DATE>>(["not-a-date"])`,
+		`STRUCT<a ARRAY<INT64>>([CAST(NULL AS STRING)])`,
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -136,13 +136,6 @@ func TestParseExpr(t *testing.T) {
 			)),
 		},
 		{
-			`STRUCT<f32 FLOAT32>(CAST(NULL AS INT64))`,
-			must(gcvctor.StructValueOf(
-				[]string{"f32"},
-				[]spanner.GenericColumnValue{gcvctor.NullOf(typector.Float32())},
-			)),
-		},
-		{
 			`STRUCT<a ARRAY<NUMERIC>>([1, NULL])`,
 			must(gcvctor.StructValueOf(
 				[]string{"a"},
@@ -176,18 +169,6 @@ func TestParseExpr(t *testing.T) {
 					must(gcvctor.ArrayValueOf(
 						typector.Date(),
 						gcvctor.DateValue(civil.Date{Year: 1970, Month: time.January, Day: 1}),
-					)),
-				},
-			)),
-		},
-		{
-			`STRUCT<a ARRAY<FLOAT32>>([CAST(NULL AS INT64)])`,
-			must(gcvctor.StructValueOf(
-				[]string{"a"},
-				[]spanner.GenericColumnValue{
-					must(gcvctor.ArrayValueOf(
-						typector.Float32(),
-						gcvctor.NullOf(typector.Float32()),
 					)),
 				},
 			)),
@@ -394,6 +375,8 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`STRUCT<a ARRAY<BYTES>>(["foo"])`,
 		`STRUCT<a ARRAY<DATE>>(["not-a-date"])`,
 		`STRUCT<a ARRAY<INT64>>([CAST(NULL AS STRING)])`,
+		`STRUCT<f32 FLOAT32>(CAST(NULL AS INT64))`,
+		`STRUCT<a ARRAY<FLOAT32>>([CAST(NULL AS INT64)])`,
 		`STRUCT<a ARRAY<FLOAT32>>([CAST(1 AS FLOAT64)])`,
 	}
 	for _, input := range tests {


### PR DESCRIPTION
## Summary
- apply typed STRUCT field expected types to locally evaluable literal fields
- support local scalar coercions for numeric literals, temporal/UUID/INTERVAL string literals, and compatible typed NULLs
- evaluate typed STRUCT ARRAY fields with strict expression-aware element coercion so invalid CAST-only conversions are rejected

Part of #13.

## Validation
- make test
- make lint
- Opus 4.7 branch review: no blocking findings
- GPT-5.5 branch review: no blocking findings