### PR TITLE
Support CAST between BYTES and UUID

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -113,7 +113,9 @@ func castGCV(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string
 		return castGCVToDate(src, exprSQL)
 	case sppb.TypeCode_TIMESTAMP:
 		return castGCVToTimestamp(src, exprSQL)
-	case sppb.TypeCode_UUID, sppb.TypeCode_INTERVAL:
+	case sppb.TypeCode_UUID:
+		return castGCVToUUID(src, exprSQL)
+	case sppb.TypeCode_INTERVAL:
 		return castStringBasedGCV(src, destCode, exprSQL)
 	default:
 		return zeroGCV, unsupportedCastError(srcCode, destCode, exprSQL)
@@ -372,14 +374,26 @@ func castGCVToString(src spanner.GenericColumnValue, exprSQL string) (spanner.Ge
 }
 
 func castGCVToBytes(src spanner.GenericColumnValue, exprSQL string) (spanner.GenericColumnValue, error) {
-	if src.Type.GetCode() != sppb.TypeCode_STRING {
+	switch src.Type.GetCode() {
+	case sppb.TypeCode_STRING:
+		v, err := stringFromGCV(src)
+		if err != nil {
+			return zeroGCV, err
+		}
+		return gcvctor.BytesValue([]byte(v)), nil
+	case sppb.TypeCode_UUID:
+		v, err := stringFromGCV(src)
+		if err != nil {
+			return zeroGCV, err
+		}
+		u, err := uuid.Parse(v)
+		if err != nil {
+			return zeroGCV, fmt.Errorf("invalid UUID value for cast of %s to BYTES: %w", exprSQL, err)
+		}
+		return gcvctor.BytesValue(u[:]), nil
+	default:
 		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_BYTES, exprSQL)
 	}
-	v, err := stringFromGCV(src)
-	if err != nil {
-		return zeroGCV, err
-	}
-	return gcvctor.BytesValue([]byte(v)), nil
 }
 
 func castGCVToDate(src spanner.GenericColumnValue, exprSQL string) (spanner.GenericColumnValue, error) {
@@ -428,6 +442,37 @@ func castGCVToTimestamp(src spanner.GenericColumnValue, exprSQL string) (spanner
 	}
 }
 
+func castGCVToUUID(src spanner.GenericColumnValue, exprSQL string) (spanner.GenericColumnValue, error) {
+	switch src.Type.GetCode() {
+	case sppb.TypeCode_STRING:
+		v, err := stringFromGCV(src)
+		if err != nil {
+			return zeroGCV, err
+		}
+		v = strings.TrimSpace(v)
+		u, err := uuid.Parse(v)
+		if err != nil || !strings.EqualFold(u.String(), v) {
+			return zeroGCV, fmt.Errorf("invalid UUID literal for cast of %s to UUID: %q", exprSQL, v)
+		}
+		return gcvctor.UUIDValue(u), nil
+	case sppb.TypeCode_BYTES:
+		v, err := bytesFromGCV(src)
+		if err != nil {
+			return zeroGCV, err
+		}
+		if len(v) != 16 {
+			return zeroGCV, fmt.Errorf("invalid BYTES length for cast of %s to UUID: expected 16, got %d", exprSQL, len(v))
+		}
+		u, err := uuid.FromBytes(v)
+		if err != nil {
+			return zeroGCV, fmt.Errorf("invalid BYTES value for cast of %s to UUID: %w", exprSQL, err)
+		}
+		return gcvctor.UUIDValue(u), nil
+	default:
+		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_UUID, exprSQL)
+	}
+}
+
 func castStringBasedGCV(src spanner.GenericColumnValue, destCode sppb.TypeCode, exprSQL string) (spanner.GenericColumnValue, error) {
 	if src.Type.GetCode() != sppb.TypeCode_STRING {
 		return zeroGCV, unsupportedCastError(src.Type.GetCode(), destCode, exprSQL)
@@ -438,12 +483,6 @@ func castStringBasedGCV(src spanner.GenericColumnValue, destCode sppb.TypeCode, 
 	}
 	v = strings.TrimSpace(v)
 	switch destCode {
-	case sppb.TypeCode_UUID:
-		u, err := uuid.Parse(v)
-		if err != nil || !strings.EqualFold(u.String(), v) {
-			return zeroGCV, fmt.Errorf("invalid UUID literal for cast of %s to UUID: %q", exprSQL, v)
-		}
-		return gcvctor.UUIDValue(u), nil
 	case sppb.TypeCode_INTERVAL:
 		return gcvctor.IntervalStringValue(v)
 	default:

--- a/cast.go
+++ b/cast.go
@@ -374,26 +374,25 @@ func castGCVToString(src spanner.GenericColumnValue, exprSQL string) (spanner.Ge
 }
 
 func castGCVToBytes(src spanner.GenericColumnValue, exprSQL string) (spanner.GenericColumnValue, error) {
-	switch src.Type.GetCode() {
-	case sppb.TypeCode_STRING:
-		v, err := stringFromGCV(src)
-		if err != nil {
-			return zeroGCV, err
-		}
-		return gcvctor.BytesValue([]byte(v)), nil
-	case sppb.TypeCode_UUID:
-		v, err := stringFromGCV(src)
-		if err != nil {
-			return zeroGCV, err
-		}
-		u, err := uuid.Parse(v)
-		if err != nil {
-			return zeroGCV, fmt.Errorf("invalid UUID value for cast of %s to BYTES: %w", exprSQL, err)
-		}
-		return gcvctor.BytesValue(u[:]), nil
-	default:
-		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_BYTES, exprSQL)
+	code := src.Type.GetCode()
+	if code != sppb.TypeCode_STRING && code != sppb.TypeCode_UUID {
+		return zeroGCV, unsupportedCastError(code, sppb.TypeCode_BYTES, exprSQL)
 	}
+
+	v, err := stringFromGCV(src)
+	if err != nil {
+		return zeroGCV, err
+	}
+
+	if code == sppb.TypeCode_STRING {
+		return gcvctor.BytesValue([]byte(v)), nil
+	}
+
+	u, err := uuid.Parse(v)
+	if err != nil {
+		return zeroGCV, fmt.Errorf("invalid UUID value %q for cast of %s to BYTES: %w", v, exprSQL, err)
+	}
+	return gcvctor.BytesValue(u[:]), nil
 }
 
 func castGCVToDate(src spanner.GenericColumnValue, exprSQL string) (spanner.GenericColumnValue, error) {

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -252,6 +252,8 @@ func TestParseExpr(t *testing.T) {
 		{`CAST(TIMESTAMP "2008-12-25 15:30:00 America/Los_Angeles" AS DATE)`, gcvctor.DateValue(civil.Date{Year: 2008, Month: time.December, Day: 25})},
 		{`CAST(" 94a01a73-d90a-432d-a03f-5db58ea8058f " AS UUID)`, gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, `94a01a73-d90a-432d-a03f-5db58ea8058f`)},
 		{`CAST(CAST("94a01a73-d90a-432d-a03f-5db58ea8058f" AS UUID) AS STRING)`, gcvctor.StringValue("94a01a73-d90a-432d-a03f-5db58ea8058f")},
+		{`CAST(b"\x00\x00\x00\x00\x00\x00\x40\x00\x80\x00\x00\x00\x00\x00\x00\x00" AS UUID)`, gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, `00000000-0000-4000-8000-000000000000`)},
+		{`CAST(CAST("00000000-0000-4000-8000-000000000000" AS UUID) AS BYTES)`, gcvctor.BytesValue([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})},
 		{`CAST(" P1Y " AS INTERVAL)`, gcvctor.StringBasedValueFromCode(sppb.TypeCode_INTERVAL, `P1Y`)},
 		{`CAST(CAST("P1Y" AS INTERVAL) AS STRING)`, gcvctor.StringValue("P1Y")},
 		{`CAST([1] AS ARRAY<INT64>)`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.Int64Value(1)))},

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -289,6 +289,7 @@ func TestParseExpr(t *testing.T) {
 		{`SAFE_CAST("2020-06-02 12:00:00 -7" AS TIMESTAMP)`, gcvctor.NullOf(typector.Timestamp())},
 		{`SAFE_CAST(PENDING_COMMIT_TIMESTAMP() AS DATE)`, gcvctor.NullOf(typector.Date())},
 		{`SAFE_CAST("not-a-uuid" AS UUID)`, gcvctor.NullOf(typector.UUID())},
+		{`SAFE_CAST(b"foo" AS UUID)`, gcvctor.NullOf(typector.UUID())},
 		{`SAFE_CAST("not-an-interval" AS INTERVAL)`, gcvctor.NullOf(typector.Interval())},
 
 		{"PENDING_COMMIT_TIMESTAMP()", gcvctor.StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, "spanner.commit_timestamp()")},
@@ -402,6 +403,7 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`CAST(1e50 AS NUMERIC)`,
 		`CAST(NUMERIC "9223372036854775807.5" AS INT64)`,
 		`CAST("not-a-uuid" AS UUID)`,
+		`CAST(b"foo" AS UUID)`,
 		`CAST("not-an-interval" AS INTERVAL)`,
 		`CAST(CAST("nan" AS FLOAT64) AS INT64)`,
 		`CAST(b"\xff" AS STRING)`,


### PR DESCRIPTION
## Summary

Add support for explicit `CAST` between `BYTES` and `UUID`, closing #20.

## Changes

- `castGCVToUUID` now handles `BYTES` input (16-byte decoding via `uuid.FromBytes`).
- `castGCVToBytes` now handles `UUID` input (16-byte encoding via `uuid.UUID[:]`).
- `castStringBasedGCV` no longer handles `UUID` (moved to dedicated `castGCVToUUID`).
- Added round-trip test cases in `memestr_to_sppb_value_test.go`.

## Verification

```
make test
make lint
```

Both pass with no issues.