### PR TITLE
Support ARRAY and STRUCT element/field type casts

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -519,12 +519,19 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 		if err != nil {
 			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v%s: %w", i, srcElemType, destElemType, exprContextSuffix(exprSQL), err)
 		}
-		coerced[i] = casted.Value
+		coerced[i] = gcvToValue(casted)
 	}
 	return spanner.GenericColumnValue{
 		Type:  destType,
 		Value: structpb.NewListValue(&structpb.ListValue{Values: coerced}),
 	}, nil
+}
+
+func gcvToValue(gcv spanner.GenericColumnValue) *structpb.Value {
+	if gcv.Value == nil {
+		return structpb.NewNullValue()
+	}
+	return gcv.Value
 }
 
 func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string) (spanner.GenericColumnValue, error) {
@@ -556,7 +563,7 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 		if err != nil {
 			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v%s: %w", i, srcFields[i].Type, destFields[i].Type, exprContextSuffix(exprSQL), err)
 		}
-		coerced[i] = casted.Value
+		coerced[i] = gcvToValue(casted)
 	}
 	return spanner.GenericColumnValue{
 		Type:  destType,

--- a/cast.go
+++ b/cast.go
@@ -93,6 +93,9 @@ func castGCV(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string
 	if proto.Equal(src.Type, destType) {
 		return spanner.GenericColumnValue{Type: destType, Value: src.Value}, nil
 	}
+	if isNullGCV(src) {
+		return gcvctor.NullOf(destType), nil
+	}
 
 	switch destCode {
 	case sppb.TypeCode_BOOL:
@@ -117,6 +120,10 @@ func castGCV(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string
 		return castGCVToUUID(src, exprSQL)
 	case sppb.TypeCode_INTERVAL:
 		return castStringBasedGCV(src, destCode, exprSQL)
+	case sppb.TypeCode_ARRAY:
+		return castGCVToArray(src, destType, exprSQL)
+	case sppb.TypeCode_STRUCT:
+		return castGCVToStruct(src, destType, exprSQL)
 	default:
 		return zeroGCV, unsupportedCastError(srcCode, destCode, exprSQL)
 	}
@@ -489,6 +496,72 @@ func castStringBasedGCV(src spanner.GenericColumnValue, destCode sppb.TypeCode, 
 	default:
 		return gcvctor.StringBasedValueFromCode(destCode, v), nil
 	}
+}
+
+func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string) (spanner.GenericColumnValue, error) {
+	if src.Type.GetCode() != sppb.TypeCode_ARRAY {
+		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_ARRAY, exprSQL)
+	}
+	srcElemType := src.Type.GetArrayElementType()
+	destElemType := destType.GetArrayElementType()
+	if proto.Equal(srcElemType, destElemType) {
+		return spanner.GenericColumnValue{Type: destType, Value: src.Value}, nil
+	}
+	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
+	if !ok {
+		return zeroGCV, fmt.Errorf("expected ARRAY wire value, got %T", src.Value.GetKind())
+	}
+	values := listValue.ListValue.Values
+	coerced := make([]*structpb.Value, len(values))
+	for i, v := range values {
+		elemGCV := spanner.GenericColumnValue{Type: srcElemType, Value: v}
+		casted, err := castGCV(elemGCV, destElemType, exprSQL)
+		if err != nil {
+			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v%s: %w", i, srcElemType, destElemType, exprContextSuffix(exprSQL), err)
+		}
+		coerced[i] = casted.Value
+	}
+	return spanner.GenericColumnValue{
+		Type:  destType,
+		Value: structpb.NewListValue(&structpb.ListValue{Values: coerced}),
+	}, nil
+}
+
+func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL string) (spanner.GenericColumnValue, error) {
+	if src.Type.GetCode() != sppb.TypeCode_STRUCT {
+		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_STRUCT, exprSQL)
+	}
+	srcFields := src.Type.GetStructType().GetFields()
+	destFields := destType.GetStructType().GetFields()
+	if len(srcFields) != len(destFields) {
+		return zeroGCV, fmt.Errorf("cannot cast STRUCT with %d fields to STRUCT with %d fields%s", len(srcFields), len(destFields), exprContextSuffix(exprSQL))
+	}
+	for i := range srcFields {
+		if srcFields[i].Name != destFields[i].Name {
+			return zeroGCV, fmt.Errorf("cannot cast STRUCT field %d: name mismatch %q vs %q%s", i, srcFields[i].Name, destFields[i].Name, exprContextSuffix(exprSQL))
+		}
+	}
+	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
+	if !ok {
+		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T", src.Value.GetKind())
+	}
+	values := listValue.ListValue.Values
+	if len(values) != len(destFields) {
+		return zeroGCV, fmt.Errorf("STRUCT value field count mismatch: expected %d, got %d%s", len(destFields), len(values), exprContextSuffix(exprSQL))
+	}
+	coerced := make([]*structpb.Value, len(values))
+	for i, v := range values {
+		elemGCV := spanner.GenericColumnValue{Type: srcFields[i].Type, Value: v}
+		casted, err := castGCV(elemGCV, destFields[i].Type, exprSQL)
+		if err != nil {
+			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v%s: %w", i, srcFields[i].Type, destFields[i].Type, exprContextSuffix(exprSQL), err)
+		}
+		coerced[i] = casted.Value
+	}
+	return spanner.GenericColumnValue{
+		Type:  destType,
+		Value: structpb.NewListValue(&structpb.ListValue{Values: coerced}),
+	}, nil
 }
 
 func isNullGCV(gcv spanner.GenericColumnValue) bool {

--- a/cast.go
+++ b/cast.go
@@ -549,6 +549,9 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
 	}
 	values := listValue.ListValue.Values
+	if len(values) != len(srcFields) {
+		return zeroGCV, fmt.Errorf("STRUCT wire value has %d fields, but type has %d fields%s", len(values), len(srcFields), exprContextSuffix(exprSQL))
+	}
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
 		elemGCV := spanner.GenericColumnValue{Type: srcFields[i].Type, Value: v}

--- a/cast.go
+++ b/cast.go
@@ -537,8 +537,16 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	if src.Type.GetCode() != sppb.TypeCode_STRUCT {
 		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_STRUCT, exprSQL)
 	}
-	srcFields := src.Type.GetStructType().GetFields()
-	destFields := destType.GetStructType().GetFields()
+	srcStructType := src.Type.GetStructType()
+	if srcStructType == nil {
+		return zeroGCV, fmt.Errorf("malformed STRUCT source type%s", exprContextSuffix(exprSQL))
+	}
+	srcFields := srcStructType.GetFields()
+	destStructType := destType.GetStructType()
+	if destStructType == nil {
+		return zeroGCV, fmt.Errorf("malformed STRUCT destination type%s", exprContextSuffix(exprSQL))
+	}
+	destFields := destStructType.GetFields()
 	if len(srcFields) != len(destFields) {
 		return zeroGCV, fmt.Errorf("cannot cast STRUCT with %d fields to STRUCT with %d fields%s", len(srcFields), len(destFields), exprContextSuffix(exprSQL))
 	}

--- a/cast.go
+++ b/cast.go
@@ -506,7 +506,7 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 	destElemType := destType.GetArrayElementType()
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {
-		return zeroGCV, fmt.Errorf("expected ARRAY wire value, got %T", src.Value.GetKind())
+		return zeroGCV, fmt.Errorf("expected ARRAY wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
 	}
 	values := listValue.ListValue.Values
 	coerced := make([]*structpb.Value, len(values))
@@ -514,7 +514,7 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 		elemGCV := spanner.GenericColumnValue{Type: srcElemType, Value: v}
 		casted, err := castGCV(elemGCV, destElemType, exprSQL)
 		if err != nil {
-			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v%s: %w", i, srcElemType, destElemType, exprContextSuffix(exprSQL), err)
+			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v%s: %w", i, srcElemType.GetCode(), destElemType.GetCode(), exprContextSuffix(exprSQL), err)
 		}
 		coerced[i] = gcvToValue(casted)
 	}
@@ -542,7 +542,7 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	}
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {
-		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T", src.Value.GetKind())
+		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
 	}
 	values := listValue.ListValue.Values
 	if len(values) != len(destFields) {
@@ -553,7 +553,7 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 		elemGCV := spanner.GenericColumnValue{Type: srcFields[i].Type, Value: v}
 		casted, err := castGCV(elemGCV, destFields[i].Type, exprSQL)
 		if err != nil {
-			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v%s: %w", i, srcFields[i].Type, destFields[i].Type, exprContextSuffix(exprSQL), err)
+			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v%s: %w", i, srcFields[i].Type.GetCode(), destFields[i].Type.GetCode(), exprContextSuffix(exprSQL), err)
 		}
 		coerced[i] = gcvToValue(casted)
 	}

--- a/cast.go
+++ b/cast.go
@@ -514,6 +514,9 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 	if !ok {
 		return zeroGCV, fmt.Errorf("expected ARRAY wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
 	}
+	if listValue.ListValue == nil {
+		return zeroGCV, fmt.Errorf("malformed ARRAY wire value: missing ListValue detail%s", exprContextSuffix(exprSQL))
+	}
 	values := listValue.ListValue.Values
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
@@ -559,6 +562,9 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {
 		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
+	}
+	if listValue.ListValue == nil {
+		return zeroGCV, fmt.Errorf("malformed STRUCT wire value: missing ListValue detail%s", exprContextSuffix(exprSQL))
 	}
 	values := listValue.ListValue.Values
 	if len(values) != len(srcFields) {

--- a/cast.go
+++ b/cast.go
@@ -512,11 +512,9 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
 		elemGCV := spanner.GenericColumnValue{Type: srcElemType, Value: v}
-		// Pass empty exprSQL so the recursive cast doesn't duplicate expression
-		// context; this wrapper owns the context via exprContextSuffix.
-		casted, err := castGCV(elemGCV, destElemType, "")
+		casted, err := castGCV(elemGCV, destElemType, exprSQL)
 		if err != nil {
-			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v%s: %w", i, srcElemType.GetCode(), destElemType.GetCode(), exprContextSuffix(exprSQL), err)
+			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v: %w", i, srcElemType.GetCode(), destElemType.GetCode(), err)
 		}
 		coerced[i] = gcvToValue(casted)
 	}
@@ -563,11 +561,9 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
 		elemGCV := spanner.GenericColumnValue{Type: srcFields[i].Type, Value: v}
-		// Pass empty exprSQL so the recursive cast doesn't duplicate expression
-		// context; this wrapper owns the context via exprContextSuffix.
-		casted, err := castGCV(elemGCV, destFields[i].Type, "")
+		casted, err := castGCV(elemGCV, destFields[i].Type, exprSQL)
 		if err != nil {
-			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v%s: %w", i, srcFields[i].Type.GetCode(), destFields[i].Type.GetCode(), exprContextSuffix(exprSQL), err)
+			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v: %w", i, srcFields[i].Type.GetCode(), destFields[i].Type.GetCode(), err)
 		}
 		coerced[i] = gcvToValue(casted)
 	}

--- a/cast.go
+++ b/cast.go
@@ -503,7 +503,13 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 		return zeroGCV, unsupportedCastError(src.Type.GetCode(), sppb.TypeCode_ARRAY, exprSQL)
 	}
 	srcElemType := src.Type.GetArrayElementType()
+	if srcElemType == nil {
+		return zeroGCV, fmt.Errorf("malformed ARRAY source type: missing element type%s", exprContextSuffix(exprSQL))
+	}
 	destElemType := destType.GetArrayElementType()
+	if destElemType == nil {
+		return zeroGCV, fmt.Errorf("malformed ARRAY destination type: missing element type%s", exprContextSuffix(exprSQL))
+	}
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {
 		return zeroGCV, fmt.Errorf("expected ARRAY wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))

--- a/cast.go
+++ b/cast.go
@@ -512,7 +512,9 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
 		elemGCV := spanner.GenericColumnValue{Type: srcElemType, Value: v}
-		casted, err := castGCV(elemGCV, destElemType, exprSQL)
+		// Pass empty exprSQL so the recursive cast doesn't duplicate expression
+		// context; this wrapper owns the context via exprContextSuffix.
+		casted, err := castGCV(elemGCV, destElemType, "")
 		if err != nil {
 			return zeroGCV, fmt.Errorf("cannot cast array element %d from %v to %v%s: %w", i, srcElemType.GetCode(), destElemType.GetCode(), exprContextSuffix(exprSQL), err)
 		}
@@ -540,6 +542,8 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	if len(srcFields) != len(destFields) {
 		return zeroGCV, fmt.Errorf("cannot cast STRUCT with %d fields to STRUCT with %d fields%s", len(srcFields), len(destFields), exprContextSuffix(exprSQL))
 	}
+	// Cloud Spanner ignores field names during STRUCT CAST and only requires
+	// the number of fields to match, so name parity is intentionally not enforced.
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {
 		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
@@ -551,7 +555,9 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
 		elemGCV := spanner.GenericColumnValue{Type: srcFields[i].Type, Value: v}
-		casted, err := castGCV(elemGCV, destFields[i].Type, exprSQL)
+		// Pass empty exprSQL so the recursive cast doesn't duplicate expression
+		// context; this wrapper owns the context via exprContextSuffix.
+		casted, err := castGCV(elemGCV, destFields[i].Type, "")
 		if err != nil {
 			return zeroGCV, fmt.Errorf("cannot cast struct field %d from %v to %v%s: %w", i, srcFields[i].Type.GetCode(), destFields[i].Type.GetCode(), exprContextSuffix(exprSQL), err)
 		}

--- a/cast.go
+++ b/cast.go
@@ -504,9 +504,6 @@ func castGCVToArray(src spanner.GenericColumnValue, destType *sppb.Type, exprSQL
 	}
 	srcElemType := src.Type.GetArrayElementType()
 	destElemType := destType.GetArrayElementType()
-	if proto.Equal(srcElemType, destElemType) {
-		return spanner.GenericColumnValue{Type: destType, Value: src.Value}, nil
-	}
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {
 		return zeroGCV, fmt.Errorf("expected ARRAY wire value, got %T", src.Value.GetKind())
@@ -542,11 +539,6 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 	destFields := destType.GetStructType().GetFields()
 	if len(srcFields) != len(destFields) {
 		return zeroGCV, fmt.Errorf("cannot cast STRUCT with %d fields to STRUCT with %d fields%s", len(srcFields), len(destFields), exprContextSuffix(exprSQL))
-	}
-	for i := range srcFields {
-		if srcFields[i].Name != destFields[i].Name {
-			return zeroGCV, fmt.Errorf("cannot cast STRUCT field %d: name mismatch %q vs %q%s", i, srcFields[i].Name, destFields[i].Name, exprContextSuffix(exprSQL))
-		}
 	}
 	listValue, ok := src.Value.GetKind().(*structpb.Value_ListValue)
 	if !ok {

--- a/cast.go
+++ b/cast.go
@@ -549,9 +549,6 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 		return zeroGCV, fmt.Errorf("expected STRUCT wire value, got %T%s", src.Value.GetKind(), exprContextSuffix(exprSQL))
 	}
 	values := listValue.ListValue.Values
-	if len(values) != len(destFields) {
-		return zeroGCV, fmt.Errorf("STRUCT value field count mismatch: expected %d, got %d%s", len(destFields), len(values), exprContextSuffix(exprSQL))
-	}
 	coerced := make([]*structpb.Value, len(values))
 	for i, v := range values {
 		elemGCV := spanner.GenericColumnValue{Type: srcFields[i].Type, Value: v}

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -582,10 +582,3 @@ func coerceArrayElementToFloat64(gcv spanner.GenericColumnValue) (spanner.Generi
 		return zeroGCV, fmt.Errorf("cannot coerce array element from %v to FLOAT64", gcv.Type.GetCode())
 	}
 }
-
-func gcvToValue(gcv spanner.GenericColumnValue) *structpb.Value {
-	if gcv.Value == nil {
-		return structpb.NewNullValue()
-	}
-	return gcv.Value
-}

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -323,6 +323,8 @@ func TestParseExpr(t *testing.T) {
 		{`SAFE_CAST(" 94a01a73-d90a-432d-a03f-5db58ea8058f " AS UUID)`, gcvctor.NullOf(typector.UUID())},
 		{`SAFE_CAST(" P1Y " AS INTERVAL)`, gcvctor.NullOf(typector.Interval())},
 		{`SAFE_CAST("not-an-interval" AS INTERVAL)`, gcvctor.NullOf(typector.Interval())},
+		{`SAFE_CAST(["not-a-date"] AS ARRAY<DATE>)`, gcvctor.NullOf(typector.ElemTypeToArrayType(typector.Date()))},
+		{`SAFE_CAST(STRUCT("not-a-date" AS foo) AS STRUCT<foo DATE>)`, gcvctor.NullOf(typector.NameTypeToStructType("foo", typector.Date()))},
 
 		{"PENDING_COMMIT_TIMESTAMP()", gcvctor.StringBasedValueFromCode(sppb.TypeCode_TIMESTAMP, "spanner.commit_timestamp()")},
 

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -278,6 +278,13 @@ func TestParseExpr(t *testing.T) {
 				[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.Int64Value(2)},
 			)),
 		},
+		{
+			`CAST(STRUCT(NULL AS foo) AS STRUCT<foo INT64>)`,
+			must(gcvctor.StructValueOf(
+				[]string{"foo"},
+				[]spanner.GenericColumnValue{gcvctor.NullOf(typector.Int64())},
+			)),
+		},
 		{`CAST(CAST(42 AS STRING) AS INT64)`, gcvctor.Int64Value(42)},
 		{`CAST("NaN" AS FLOAT64)`, gcvctor.Float64Value(math.NaN())},
 		{`CAST("Infinity" AS FLOAT64)`, gcvctor.Float64Value(math.Inf(1))},

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -254,11 +254,28 @@ func TestParseExpr(t *testing.T) {
 		{`CAST(CAST("00000000-0000-4000-8000-000000000000" AS UUID) AS BYTES)`, gcvctor.BytesValue([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})},
 		{`CAST(CAST("P1Y" AS INTERVAL) AS STRING)`, gcvctor.StringValue("P1Y")},
 		{`CAST([1] AS ARRAY<INT64>)`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.Int64Value(1)))},
+		{`CAST([1] AS ARRAY<FLOAT64>)`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1.0)))},
+		{`CAST([NUMERIC "1.5"] AS ARRAY<FLOAT64>)`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1.5)))},
+		{`CAST([1, NULL] AS ARRAY<FLOAT64>)`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1.0), gcvctor.NullOf(typector.Float64())))},
 		{
 			`CAST(STRUCT(1 AS foo) AS STRUCT<foo INT64>)`,
 			must(gcvctor.StructValueOf(
 				[]string{"foo"},
 				[]spanner.GenericColumnValue{gcvctor.Int64Value(1)},
+			)),
+		},
+		{
+			`CAST(STRUCT(1 AS foo) AS STRUCT<foo FLOAT64>)`,
+			must(gcvctor.StructValueOf(
+				[]string{"foo"},
+				[]spanner.GenericColumnValue{gcvctor.Float64Value(1.0)},
+			)),
+		},
+		{
+			`CAST(STRUCT(1 AS foo, "2" AS bar) AS STRUCT<foo INT64, bar INT64>)`,
+			must(gcvctor.StructValueOf(
+				[]string{"foo", "bar"},
+				[]spanner.GenericColumnValue{gcvctor.Int64Value(1), gcvctor.Int64Value(2)},
 			)),
 		},
 		{`CAST(CAST(42 AS STRING) AS INT64)`, gcvctor.Int64Value(42)},
@@ -446,6 +463,9 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`STRUCT<f32 FLOAT32>(CAST(NULL AS INT64))`,
 		`STRUCT<a ARRAY<FLOAT32>>([CAST(NULL AS INT64)])`,
 		`STRUCT<a ARRAY<FLOAT32>>([CAST(1 AS FLOAT64)])`,
+		`CAST([1] AS ARRAY<BYTES>)`,
+		`CAST(STRUCT(1 AS foo) AS STRUCT<bar INT64>)`,
+		`CAST(STRUCT(1 AS foo, 2 AS bar) AS STRUCT<foo INT64>)`,
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -285,6 +285,13 @@ func TestParseExpr(t *testing.T) {
 				[]spanner.GenericColumnValue{gcvctor.NullOf(typector.Int64())},
 			)),
 		},
+		{
+			`CAST(STRUCT(1 AS foo) AS STRUCT<bar INT64>)`,
+			must(gcvctor.StructValueOf(
+				[]string{"bar"},
+				[]spanner.GenericColumnValue{gcvctor.Int64Value(1)},
+			)),
+		},
 		{`CAST(CAST(42 AS STRING) AS INT64)`, gcvctor.Int64Value(42)},
 		{`CAST("NaN" AS FLOAT64)`, gcvctor.Float64Value(math.NaN())},
 		{`CAST("Infinity" AS FLOAT64)`, gcvctor.Float64Value(math.Inf(1))},
@@ -471,7 +478,6 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`STRUCT<a ARRAY<FLOAT32>>([CAST(NULL AS INT64)])`,
 		`STRUCT<a ARRAY<FLOAT32>>([CAST(1 AS FLOAT64)])`,
 		`CAST([1] AS ARRAY<BYTES>)`,
-		`CAST(STRUCT(1 AS foo) AS STRUCT<bar INT64>)`,
 		`CAST(STRUCT(1 AS foo, 2 AS bar) AS STRUCT<foo INT64>)`,
 	}
 	for _, input := range tests {

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -467,6 +467,7 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 		`CAST(PENDING_COMMIT_TIMESTAMP() AS DATE)`,
 		`SAFE_CAST(TRUE AS BYTES)`,
 		`SAFE_CAST([1] AS INT64)`,
+		`SAFE_CAST([1] AS ARRAY<BYTES>)`,
 		`STRUCT<i INT64>("1")`,
 		`STRUCT<b BYTES>("foo")`,
 		`STRUCT<i INT64>(CAST(NULL AS STRING))`,


### PR DESCRIPTION
## Summary

Add support for casting ARRAY and STRUCT values by recursively converting each element or field to the destination type.

## Changes

- `castGCV`: add `isNullGCV` guard so nested casts (array elements, struct fields) correctly propagate typed NULLs.
- `castGCVToArray`: new helper that iterates over array elements and calls `castGCV` with the destination element type.
- `castGCVToStruct`: new helper that iterates over struct fields positionally and calls `castGCV` with the destination field type. Cloud Spanner ignores field names during STRUCT CAST, so name parity is not enforced.

## Test updates

- Success cases:
  - `CAST([1] AS ARRAY<FLOAT64>)`
  - `CAST([NUMERIC "1.5"] AS ARRAY<FLOAT64>)`
  - `CAST([1, NULL] AS ARRAY<FLOAT64>)`
  - `CAST(STRUCT(1 AS foo) AS STRUCT<foo FLOAT64>)`
  - `CAST(STRUCT(1 AS foo, "2" AS bar) AS STRUCT<foo INT64, bar INT64>)`
  - `CAST(STRUCT(1 AS foo) AS STRUCT<bar INT64>)` (name ignored, count matches)
- Error cases:
  - `CAST([1] AS ARRAY<BYTES>)`
  - `CAST(STRUCT(1 AS foo, 2 AS bar) AS STRUCT<foo INT64>)` (field count mismatch)

## Verification

```
make test
make lint
```

Both pass.

Closes #22
Closes #23