### PR TITLE
Support array literal supertype inference and string-literal coercion

### DIFF
--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -404,8 +404,9 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 		return typector.Int64()
 	}
 	if hasOther {
-		// When STRING literals are mixed with a single non-STRING type,
-		// prefer the non-STRING type so that string coercion can apply.
+		// When STRING values are mixed with a single non-STRING type,
+		// prefer the non-STRING type so that string coercion can apply,
+		// but only for scalar types that actually support STRING casts.
 		var nonStringType *sppb.Type
 		for i, expr := range exprs {
 			if _, ok := unwrapParenExpr(expr).(*ast.NullLiteral); ok {
@@ -420,7 +421,7 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 				}
 			}
 		}
-		if nonStringType != nil {
+		if nonStringType != nil && isStringCastableTypeCode(nonStringType.GetCode()) {
 			return nonStringType
 		}
 		return first
@@ -439,6 +440,15 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 		return typector.Int64()
 	default:
 		return first
+	}
+}
+
+func isStringCastableTypeCode(code sppb.TypeCode) bool {
+	switch code {
+	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT, sppb.TypeCode_JSON:
+		return false
+	default:
+		return true
 	}
 }
 
@@ -535,7 +545,7 @@ func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (sp
 	// that are safe locally; CAST-only conversions such as FLOAT64 to NUMERIC
 	// and NUMERIC to FLOAT32 intentionally fall back to preserving wire values.
 
-	// Allow STRING literals to coerce to any type that CAST supports.
+	// Allow STRING values to coerce to any type that CAST supports.
 	if gcv.Type.GetCode() == sppb.TypeCode_STRING {
 		return castGCV(gcv, elemType, "")
 	}

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -443,6 +443,11 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 	}
 }
 
+// isStringCastableTypeCode reports whether castGCV supports STRING -> code.
+// It returns true for all scalar types because castGCV validates the specific
+// conversion (e.g., parsing BOOL, INT64, BYTES). Complex types are excluded
+// because castGCV does not currently support STRING->JSON, and ARRAY/STRUCT
+// require structured parsing rather than a simple string cast.
 func isStringCastableTypeCode(code sppb.TypeCode) bool {
 	switch code {
 	case sppb.TypeCode_ARRAY, sppb.TypeCode_STRUCT, sppb.TypeCode_JSON:

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -534,6 +534,12 @@ func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (sp
 	// This is not the full CAST matrix. It only models array literal coercions
 	// that are safe locally; CAST-only conversions such as FLOAT64 to NUMERIC
 	// and NUMERIC to FLOAT32 intentionally fall back to preserving wire values.
+
+	// Allow STRING literals to coerce to any type that CAST supports.
+	if gcv.Type.GetCode() == sppb.TypeCode_STRING {
+		return castGCV(gcv, elemType, "")
+	}
+
 	switch elemType.GetCode() {
 	case sppb.TypeCode_NUMERIC:
 		if gcv.Type.GetCode() == sppb.TypeCode_INT64 {
@@ -547,11 +553,6 @@ func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (sp
 		return coerceArrayElementToFloat32(gcv)
 	case sppb.TypeCode_FLOAT64:
 		return coerceArrayElementToFloat64(gcv)
-	}
-
-	// Allow STRING literals to coerce to any type that CAST supports.
-	if gcv.Type.GetCode() == sppb.TypeCode_STRING {
-		return castGCV(gcv, elemType, "")
 	}
 
 	return zeroGCV, fmt.Errorf("cannot coerce array element from %v to %v", gcv.Type.GetCode(), elemType.GetCode())
@@ -593,13 +594,9 @@ func coerceArrayElementToFloat64(gcv spanner.GenericColumnValue) (spanner.Generi
 		}
 		return gcvctor.Float64Value(v), nil
 	case sppb.TypeCode_NUMERIC:
-		v, err := stringFromGCV(gcv)
+		n, err := numericFromGCV(gcv)
 		if err != nil {
 			return zeroGCV, err
-		}
-		n, ok := new(big.Rat).SetString(v)
-		if !ok {
-			return zeroGCV, fmt.Errorf("invalid NUMERIC wire value: %q", v)
 		}
 		f, _ := n.Float64()
 		return gcvctor.Float64Value(f), nil

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -404,6 +404,25 @@ func inferArrayElementType(exprs []ast.Expr, gcvs []spanner.GenericColumnValue) 
 		return typector.Int64()
 	}
 	if hasOther {
+		// When STRING literals are mixed with a single non-STRING type,
+		// prefer the non-STRING type so that string coercion can apply.
+		var nonStringType *sppb.Type
+		for i, expr := range exprs {
+			if _, ok := unwrapParenExpr(expr).(*ast.NullLiteral); ok {
+				continue
+			}
+			typ := gcvs[i].Type
+			if typ.GetCode() != sppb.TypeCode_STRING {
+				if nonStringType == nil {
+					nonStringType = typ
+				} else if !proto.Equal(nonStringType, typ) {
+					return first
+				}
+			}
+		}
+		if nonStringType != nil {
+			return nonStringType
+		}
 		return first
 	}
 
@@ -529,6 +548,12 @@ func coerceArrayElement(elemType *sppb.Type, gcv spanner.GenericColumnValue) (sp
 	case sppb.TypeCode_FLOAT64:
 		return coerceArrayElementToFloat64(gcv)
 	}
+
+	// Allow STRING literals to coerce to any type that CAST supports.
+	if gcv.Type.GetCode() == sppb.TypeCode_STRING {
+		return castGCV(gcv, elemType, "")
+	}
+
 	return zeroGCV, fmt.Errorf("cannot coerce array element from %v to %v", gcv.Type.GetCode(), elemType.GetCode())
 }
 

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/apstndb/spantype/typector"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/apstndb/memebridge"
@@ -81,7 +82,9 @@ func TestParseExpr(t *testing.T) {
 		{`ARRAY<FLOAT32>[1, 2.5]`, must(gcvctor.ArrayValueOf(typector.Float32(), gcvctor.Float32Value(1), gcvctor.Float32Value(2.5)))},
 		{`[1, "2"]`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.Int64Value(1), gcvctor.Int64Value(2)))},
 		{`["2020-01-01", DATE "2020-01-02"]`, must(gcvctor.ArrayValueOf(typector.Date(), gcvctor.DateValue(civil.Date{Year: 2020, Month: time.January, Day: 1}), gcvctor.DateValue(civil.Date{Year: 2020, Month: time.January, Day: 2})))},
-		{`["foo", NULL]`, must(gcvctor.ArrayValueOf(typector.String(), gcvctor.StringValue("foo"), gcvctor.NullOf(typector.String())))},
+		{`["2020-01-01T00:00:00Z", TIMESTAMP "2020-01-02T00:00:00Z"]`, must(gcvctor.ArrayValueOf(typector.Timestamp(), gcvctor.TimestampValue(time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)), gcvctor.TimestampValue(time.Date(2020, time.January, 2, 0, 0, 0, 0, time.UTC))))},
+		{`["94a01a73-d90a-432d-a03f-5db58ea8058f", CAST("94a01a73-d90a-432d-a03f-5db58ea8058f" AS UUID)]`, must(gcvctor.ArrayValueOf(typector.UUID(), gcvctor.UUIDValue(must(uuid.Parse("94a01a73-d90a-432d-a03f-5db58ea8058f"))), gcvctor.UUIDValue(must(uuid.Parse("94a01a73-d90a-432d-a03f-5db58ea8058f")))))},
+		{`["P1Y", CAST("P2Y" AS INTERVAL)]`, must(gcvctor.ArrayValueOf(typector.Interval(), gcvctor.StringBasedValueFromCode(sppb.TypeCode_INTERVAL, "P1Y"), gcvctor.StringBasedValueFromCode(sppb.TypeCode_INTERVAL, "P2Y")))},
 		{
 			`(1, "foo", 3.14)`,
 			must(gcvctor.StructValueOf(

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -79,6 +79,9 @@ func TestParseExpr(t *testing.T) {
 		},
 		{`ARRAY<FLOAT64>[1, NUMERIC "2.5"]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1), gcvctor.Float64Value(2.5)))},
 		{`ARRAY<FLOAT32>[1, 2.5]`, must(gcvctor.ArrayValueOf(typector.Float32(), gcvctor.Float32Value(1), gcvctor.Float32Value(2.5)))},
+		{`[1, "2"]`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.Int64Value(1), gcvctor.Int64Value(2)))},
+		{`["2020-01-01", DATE "2020-01-02"]`, must(gcvctor.ArrayValueOf(typector.Date(), gcvctor.DateValue(civil.Date{Year: 2020, Month: time.January, Day: 1}), gcvctor.DateValue(civil.Date{Year: 2020, Month: time.January, Day: 2})))},
+		{`["foo", NULL]`, must(gcvctor.ArrayValueOf(typector.String(), gcvctor.StringValue("foo"), gcvctor.NullOf(typector.String())))},
 		{
 			`(1, "foo", 3.14)`,
 			must(gcvctor.StructValueOf(

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -59,6 +59,10 @@ func TestParseExpr(t *testing.T) {
 		{`[NULL, NULL]`, must(gcvctor.ArrayValueOf(typector.Int64(), gcvctor.NullOf(typector.Int64()), gcvctor.NullOf(typector.Int64())))},
 		{`[CAST(NULL AS STRING)]`, must(gcvctor.ArrayValueOf(typector.String(), gcvctor.NullOf(typector.String())))},
 		{`["foo", NULL]`, must(gcvctor.ArrayValueOf(typector.String(), gcvctor.StringValue("foo"), gcvctor.NullOf(typector.String())))},
+		{`[DATE "1970-01-01", "1970-01-02"]`, must(gcvctor.ArrayValueOf(typector.Date(), gcvctor.DateValue(civil.Date{Year: 1970, Month: time.January, Day: 1}), gcvctor.DateValue(civil.Date{Year: 1970, Month: time.January, Day: 2})))},
+		{`[TIMESTAMP "1970-01-01T00:00:00Z", "2020-06-02T00:00:00Z"]`, must(gcvctor.ArrayValueOf(typector.Timestamp(), gcvctor.TimestampValue(time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)), gcvctor.TimestampValue(time.Date(2020, time.June, 2, 0, 0, 0, 0, time.UTC))))},
+		{`[CAST("94a01a73-d90a-432d-a03f-5db58ea8058f" AS UUID), "94a01a73-d90a-432d-a03f-5db58ea8058f"]`, must(gcvctor.ArrayValueOf(typector.UUID(), gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, "94a01a73-d90a-432d-a03f-5db58ea8058f"), gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, "94a01a73-d90a-432d-a03f-5db58ea8058f")))},
+		{`[CAST("P1Y" AS INTERVAL), "P2Y"]`, must(gcvctor.ArrayValueOf(typector.Interval(), gcvctor.StringBasedValueFromCode(sppb.TypeCode_INTERVAL, "P1Y"), gcvctor.StringBasedValueFromCode(sppb.TypeCode_INTERVAL, "P2Y")))},
 		{`[1, 2.5]`, must(gcvctor.ArrayValueOf(typector.Float64(), gcvctor.Float64Value(1), gcvctor.Float64Value(2.5)))},
 		{
 			`[1, NUMERIC "2.5"]`,


### PR DESCRIPTION
## Summary

Improve array literal type inference so that STRING literals mixed with a single non-STRING type resolve to the non-STRING type, and allow STRING elements to coerce to any type supported by CAST.

## Changes

- `inferArrayElementType`: when `hasOther` is true (non-numeric types present), detect whether all non-STRING elements share the same type and return that type instead of defaulting to the first element's type.
- `coerceArrayElement`: fall back to `castGCV` for STRING source elements, enabling STRING → INT64/DATE/TIMESTAMP/UUID/INTERVAL/etc. coercion inside array literals.

## Test updates

- `[1, "2"]` → `ARRAY<INT64>`
- `["2020-01-01", DATE "2020-01-02"]` → `ARRAY<DATE>`
- `["foo", NULL]` → `ARRAY<STRING>`

## Verification

```
make test
make lint
```

Both pass.

Closes #24