### PR TITLE
Add cliparams subpackage for CLI parameter assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 memebridge is a Go package to convert between [`memefish/ast.Type`](https://pkg.go.dev/github.com/cloudspannerecosystem/memefish/ast#Type) and [`spannerpb.Type`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#Type), and to convert `memefish` expressions into `cloud.google.com/go/spanner.GenericColumnValue`.
 
+The [`cliparams`](https://pkg.go.dev/github.com/apstndb/memebridge/cliparams) subpackage converts CLI-style query parameter assignments (`name:value` flags or already-split maps) into `spanner.GenericColumnValue` maps. It is shared by [spanner-mycli](https://github.com/apstndb/spanner-mycli) and [execspansql](https://github.com/apstndb/execspansql).
+
 ## Compatibility
 
 - `memebridge v0.5.0` requires `github.com/apstndb/spanvalue v0.2.x`.

--- a/cliparams/cliparams.go
+++ b/cliparams/cliparams.go
@@ -33,7 +33,9 @@ type config struct {
 func newConfig(opts []Option) config {
 	cfg := config{separator: ":"}
 	for _, opt := range opts {
-		opt(&cfg)
+		if opt != nil {
+			opt(&cfg)
+		}
 	}
 	return cfg
 }
@@ -60,6 +62,9 @@ func WithBareTypeAsNull() Option {
 // be non-empty; the value may contain further separator occurrences.
 func SplitAssignment(arg string, opts ...Option) (name, value string, err error) {
 	cfg := newConfig(opts)
+	if cfg.separator == "" {
+		return "", "", fmt.Errorf("cliparams: separator must not be empty")
+	}
 	name, value, found := strings.Cut(arg, cfg.separator)
 	if !found {
 		return "", "", fmt.Errorf("cliparams: assignment %q does not contain separator %q", arg, cfg.separator)
@@ -123,6 +128,9 @@ func ParseAssignments(args []string, opts ...Option) (map[string]spanner.Generic
 func ParseMap(values map[string]string, opts ...Option) (map[string]spanner.GenericColumnValue, error) {
 	params := make(map[string]spanner.GenericColumnValue, len(values))
 	for name, value := range values {
+		if name == "" {
+			return nil, fmt.Errorf("cliparams: empty parameter name")
+		}
 		gcv, err := ParseValue(value, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("cliparams: parameter %q: %w", name, err)
@@ -136,6 +144,9 @@ func ParseMap(values map[string]string, opts ...Option) (map[string]spanner.Gene
 // [cloud.google.com/go/spanner.Statement] Params. Values stay
 // [spanner.GenericColumnValue] (the client supports it directly).
 func StatementParams(params map[string]spanner.GenericColumnValue) map[string]any {
+	if params == nil {
+		return nil
+	}
 	out := make(map[string]any, len(params))
 	for name, gcv := range params {
 		out[name] = gcv

--- a/cliparams/cliparams.go
+++ b/cliparams/cliparams.go
@@ -1,0 +1,144 @@
+// Package cliparams converts CLI-style query parameter assignments
+// ("name:value" arguments or already-split name→value maps) into
+// [cloud.google.com/go/spanner.GenericColumnValue] maps, using memefish
+// literal parsing via [github.com/apstndb/memebridge].
+//
+// It extracts the parameter handling shared by spanner-mycli and
+// execspansql: each value string is parsed as a GoogleSQL expression
+// literal, and — when [WithBareTypeAsNull] is enabled — a value that parses
+// as a bare type (for example "ARRAY<STRING>") yields a typed NULL
+// parameter instead, which is how PLAN-mode tools declare parameter types
+// without values.
+package cliparams
+
+import (
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/cloudspannerecosystem/memefish"
+
+	"github.com/apstndb/memebridge"
+)
+
+// Option configures parsing.
+type Option func(*config)
+
+type config struct {
+	separator      string
+	bareTypeAsNull bool
+}
+
+func newConfig(opts []Option) config {
+	cfg := config{separator: ":"}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// WithSeparator sets the name/value separator used by [SplitAssignment] and
+// [ParseAssignments]. The default is ":"; flag conventions using "=" can
+// pass WithSeparator("="). The assignment splits at the first occurrence,
+// so values may contain the separator.
+func WithSeparator(separator string) Option {
+	return func(cfg *config) { cfg.separator = separator }
+}
+
+// WithBareTypeAsNull accepts a bare type as an assignment value, producing
+// a typed NULL parameter (for example "p:ARRAY<STRING>" → NULL
+// ARRAY<STRING>). This matches how PLAN-mode tools declare parameter types;
+// without this option such values fail expression parsing. Note that with
+// this option enabled, a value that is both a valid type and a valid
+// expression is interpreted as a type.
+func WithBareTypeAsNull() Option {
+	return func(cfg *config) { cfg.bareTypeAsNull = true }
+}
+
+// SplitAssignment splits one "name<separator>value" argument. The name must
+// be non-empty; the value may contain further separator occurrences.
+func SplitAssignment(arg string, opts ...Option) (name, value string, err error) {
+	cfg := newConfig(opts)
+	name, value, found := strings.Cut(arg, cfg.separator)
+	if !found {
+		return "", "", fmt.Errorf("cliparams: assignment %q does not contain separator %q", arg, cfg.separator)
+	}
+	if name == "" {
+		return "", "", fmt.Errorf("cliparams: assignment %q has an empty parameter name", arg)
+	}
+	return name, value, nil
+}
+
+// ParseValue converts one parameter value string into a
+// [spanner.GenericColumnValue]: a GoogleSQL expression literal, or — with
+// [WithBareTypeAsNull] — a bare type yielding a typed NULL.
+func ParseValue(value string, opts ...Option) (spanner.GenericColumnValue, error) {
+	cfg := newConfig(opts)
+	if cfg.bareTypeAsNull {
+		if typ, err := memefish.ParseType("", value); err == nil {
+			t, err := memebridge.MemefishTypeToSpannerpbType(typ)
+			if err != nil {
+				return spanner.GenericColumnValue{}, fmt.Errorf("cliparams: generating typed NULL for %q: %w", value, err)
+			}
+			return gcvctor.NullOf(t), nil
+		}
+		// Not a type; fall through to expression parsing.
+	}
+	expr, err := memefish.ParseExpr("", value)
+	if err != nil {
+		return spanner.GenericColumnValue{}, fmt.Errorf("cliparams: parsing expression %q: %w", value, err)
+	}
+	gcv, err := memebridge.MemefishExprToGCV(expr)
+	if err != nil {
+		return spanner.GenericColumnValue{}, fmt.Errorf("cliparams: generating value for %q: %w", value, err)
+	}
+	return gcv, nil
+}
+
+// ParseAssignments parses raw "name<separator>value" arguments into a
+// parameter map. Duplicate names are an error.
+func ParseAssignments(args []string, opts ...Option) (map[string]spanner.GenericColumnValue, error) {
+	params := make(map[string]spanner.GenericColumnValue, len(args))
+	for _, arg := range args {
+		name, value, err := SplitAssignment(arg, opts...)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := params[name]; ok {
+			return nil, fmt.Errorf("cliparams: duplicate parameter name %q", name)
+		}
+		gcv, err := ParseValue(value, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("cliparams: parameter %q: %w", name, err)
+		}
+		params[name] = gcv
+	}
+	return params, nil
+}
+
+// ParseMap converts an already-split name→value map (the shape produced by
+// flag libraries with map values) into a parameter map. The separator
+// option is irrelevant here.
+func ParseMap(values map[string]string, opts ...Option) (map[string]spanner.GenericColumnValue, error) {
+	params := make(map[string]spanner.GenericColumnValue, len(values))
+	for name, value := range values {
+		gcv, err := ParseValue(value, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("cliparams: parameter %q: %w", name, err)
+		}
+		params[name] = gcv
+	}
+	return params, nil
+}
+
+// StatementParams widens a parameter map to the map[string]any shape of
+// [cloud.google.com/go/spanner.Statement] Params. Values stay
+// [spanner.GenericColumnValue] (the client supports it directly).
+func StatementParams(params map[string]spanner.GenericColumnValue) map[string]any {
+	out := make(map[string]any, len(params))
+	for name, gcv := range params {
+		out[name] = gcv
+	}
+	return out
+}

--- a/cliparams/cliparams.go
+++ b/cliparams/cliparams.go
@@ -9,6 +9,12 @@
 // as a bare type (for example "ARRAY<STRING>") yields a typed NULL
 // parameter instead, which is how PLAN-mode tools declare parameter types
 // without values.
+//
+// Callers that only bind parameters referenced by the SQL (for example
+// spanner-mycli in NORMAL mode) should filter the input map to used names
+// before calling [ParseMap]. With [WithBareTypeAsNull] enabled, bare-type
+// values are parsed eagerly; filtering avoids producing typed NULL params
+// for names that the statement does not reference.
 package cliparams
 
 import (

--- a/cliparams/cliparams_test.go
+++ b/cliparams/cliparams_test.go
@@ -1,0 +1,147 @@
+package cliparams_test
+
+import (
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype/typector"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/apstndb/memebridge/cliparams"
+)
+
+func gcvOf(typ *sppb.Type, value *structpb.Value) spanner.GenericColumnValue {
+	return spanner.GenericColumnValue{Type: typ, Value: value}
+}
+
+func TestParseValue(t *testing.T) {
+	for _, tt := range []struct {
+		value string
+		opts  []cliparams.Option
+		want  spanner.GenericColumnValue
+	}{
+		{`1`, nil, gcvOf(typector.CodeToSimpleType(sppb.TypeCode_INT64), structpb.NewStringValue("1"))},
+		{`"foo"`, nil, gcvOf(typector.CodeToSimpleType(sppb.TypeCode_STRING), structpb.NewStringValue("foo"))},
+		{`TRUE`, nil, gcvOf(typector.CodeToSimpleType(sppb.TypeCode_BOOL), structpb.NewBoolValue(true))},
+		{
+			`["foo"]`, nil,
+			gcvOf(typector.ElemCodeToArrayType(sppb.TypeCode_STRING),
+				structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{structpb.NewStringValue("foo")}})),
+		},
+		{
+			`ARRAY<STRING>`, []cliparams.Option{cliparams.WithBareTypeAsNull()},
+			gcvOf(typector.ElemCodeToArrayType(sppb.TypeCode_STRING), structpb.NewNullValue()),
+		},
+		{
+			`STRUCT<x INT64>`, []cliparams.Option{cliparams.WithBareTypeAsNull()},
+			gcvOf(typector.NameCodeToStructType("x", sppb.TypeCode_INT64), structpb.NewNullValue()),
+		},
+	} {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := cliparams.ParseValue(tt.value, tt.opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("ParseValue(%q) mismatch (-want +got):\n%s", tt.value, diff)
+			}
+		})
+	}
+
+	t.Run("bare type rejected without option", func(t *testing.T) {
+		if _, err := cliparams.ParseValue(`ARRAY<STRING>`); err == nil {
+			t.Error("ParseValue without WithBareTypeAsNull: want error, got nil")
+		}
+	})
+	t.Run("invalid expression", func(t *testing.T) {
+		if _, err := cliparams.ParseValue(`(`); err == nil {
+			t.Error("want error, got nil")
+		}
+	})
+}
+
+func TestSplitAssignment(t *testing.T) {
+	for _, tt := range []struct {
+		arg       string
+		opts      []cliparams.Option
+		wantName  string
+		wantValue string
+		wantErr   bool
+	}{
+		{arg: `p1:1`, wantName: "p1", wantValue: "1"},
+		// The value may contain the separator: split at the first occurrence.
+		{arg: `ts:TIMESTAMP "2026-01-01T00:00:00Z"`, wantName: "ts", wantValue: `TIMESTAMP "2026-01-01T00:00:00Z"`},
+		{arg: `p1=1`, opts: []cliparams.Option{cliparams.WithSeparator("=")}, wantName: "p1", wantValue: "1"},
+		{arg: `p1`, wantErr: true},
+		{arg: `:1`, wantErr: true},
+	} {
+		t.Run(tt.arg, func(t *testing.T) {
+			name, value, err := cliparams.SplitAssignment(tt.arg, tt.opts...)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("SplitAssignment(%q): want error, got (%q, %q)", tt.arg, name, value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name != tt.wantName || value != tt.wantValue {
+				t.Errorf("SplitAssignment(%q) = (%q, %q), want (%q, %q)", tt.arg, name, value, tt.wantName, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestParseAssignments(t *testing.T) {
+	got, err := cliparams.ParseAssignments([]string{`a:1`, `b:"x"`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]spanner.GenericColumnValue{
+		"a": gcvOf(typector.CodeToSimpleType(sppb.TypeCode_INT64), structpb.NewStringValue("1")),
+		"b": gcvOf(typector.CodeToSimpleType(sppb.TypeCode_STRING), structpb.NewStringValue("x")),
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("ParseAssignments mismatch (-want +got):\n%s", diff)
+	}
+
+	t.Run("duplicate names", func(t *testing.T) {
+		if _, err := cliparams.ParseAssignments([]string{`a:1`, `a:2`}); err == nil || !strings.Contains(err.Error(), "duplicate") {
+			t.Errorf("want duplicate error, got %v", err)
+		}
+	})
+	t.Run("per-name error context", func(t *testing.T) {
+		_, err := cliparams.ParseAssignments([]string{`bad:(`})
+		if err == nil || !strings.Contains(err.Error(), `"bad"`) {
+			t.Errorf("want error mentioning parameter name, got %v", err)
+		}
+	})
+}
+
+func TestParseMap(t *testing.T) {
+	got, err := cliparams.ParseMap(map[string]string{"n": "NUMERIC '1'"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got["n"].Type.GetCode() != sppb.TypeCode_NUMERIC {
+		t.Errorf("ParseMap = %v, want NUMERIC param n", got)
+	}
+}
+
+func TestStatementParams(t *testing.T) {
+	params := map[string]spanner.GenericColumnValue{
+		"a": gcvOf(typector.CodeToSimpleType(sppb.TypeCode_INT64), structpb.NewStringValue("1")),
+	}
+	stmt := spanner.Statement{SQL: "SELECT @a", Params: cliparams.StatementParams(params)}
+	if len(stmt.Params) != 1 {
+		t.Errorf("Params = %v, want 1 entry", stmt.Params)
+	}
+	if _, ok := stmt.Params["a"].(spanner.GenericColumnValue); !ok {
+		t.Errorf("Params[a] = %T, want spanner.GenericColumnValue", stmt.Params["a"])
+	}
+}

--- a/cliparams/cliparams_test.go
+++ b/cliparams/cliparams_test.go
@@ -115,6 +115,11 @@ func TestParseAssignments(t *testing.T) {
 			t.Errorf("want duplicate error, got %v", err)
 		}
 	})
+	t.Run("empty separator rejected", func(t *testing.T) {
+		if _, _, err := cliparams.SplitAssignment("a:1", cliparams.WithSeparator("")); err == nil {
+			t.Error("want error for empty separator, got nil")
+		}
+	})
 	t.Run("per-name error context", func(t *testing.T) {
 		_, err := cliparams.ParseAssignments([]string{`bad:(`})
 		if err == nil || !strings.Contains(err.Error(), `"bad"`) {
@@ -133,6 +138,12 @@ func TestParseMap(t *testing.T) {
 	}
 }
 
+func TestParseMapEmptyName(t *testing.T) {
+	if _, err := cliparams.ParseMap(map[string]string{"": "1"}); err == nil {
+		t.Error("want error for empty parameter name, got nil")
+	}
+}
+
 func TestStatementParams(t *testing.T) {
 	params := map[string]spanner.GenericColumnValue{
 		"a": gcvOf(typector.CodeToSimpleType(sppb.TypeCode_INT64), structpb.NewStringValue("1")),
@@ -143,5 +154,9 @@ func TestStatementParams(t *testing.T) {
 	}
 	if _, ok := stmt.Params["a"].(spanner.GenericColumnValue); !ok {
 		t.Errorf("Params[a] = %T, want spanner.GenericColumnValue", stmt.Params["a"])
+	}
+
+	if got := cliparams.StatementParams(nil); got != nil {
+		t.Errorf("StatementParams(nil) = %v, want nil", got)
 	}
 }


### PR DESCRIPTION
## Summary

New `cliparams` subpackage extracting the CLI query-parameter handling that is currently duplicated between [spanner-mycli](https://github.com/apstndb/spanner-mycli) (`parseParams` in config.go + `generateParams` in statements.go) and [execspansql](https://github.com/apstndb/execspansql) (`params.GenerateParams`):

- `ParseValue(value, opts...)` — value string → `spanner.GenericColumnValue` via `memefish.ParseExpr` + `MemefishExprToGCV`.
- `WithBareTypeAsNull()` — accepts a bare type (e.g. `ARRAY<STRING>`) and yields a typed NULL via `MemefishTypeToSpannerpbType` + `gcvctor.NullOf`, the PLAN-mode convention for declaring parameter types. Off by default so NORMAL-mode tools keep strict expression parsing (execspansql's `permitType` gate; spanner-mycli currently always permits and can opt in).
- `SplitAssignment` / `ParseAssignments` — raw `name:value` arguments with a **configurable separator** (`WithSeparator("=")` for `=`-style flags); splits at the first occurrence so values may contain the separator (e.g. `ts:TIMESTAMP "...T00:00:00Z"`); duplicate names error.
- `ParseMap` — already-split name→value maps (flag-library output shape).
- `StatementParams` — widens `map[string]GenericColumnValue` to `spanner.Statement`'s `map[string]any`.

No new module dependencies (`gcvctor` is already used by cast.go; spannulls is not needed).

## Commands run

- `go test ./...`
- `make lint`

## Context

Extraction target identified while surveying spanner-mycli / spannersh / execspansql for common-module candidates; spanenc deliberately does not cover string-literal→GCV, so this belongs in memebridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)