### PR TITLE
Harden CI and local tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,5 +18,13 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Vet
+        run: go vet ./...
+      - name: Build with tzdata tag
+        run: go build -tags memebridge_tzdata ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
       - name: Test
-        run: go test -v ./...
+        run: go test -race -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+# Pinned for CI golangci-lint v2.11.4 (see .github/workflows/go.yml).
+version: "2"
+linters:
+  default: standard

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test lint vet fmt
 
 test:
-	go test -v ./...
+	go test -v -race -tags memebridge_tzdata ./...
 
 lint:
 	golangci-lint run
@@ -10,4 +10,4 @@ vet:
 	go vet ./...
 
 fmt:
-	gofmt -w .
+	gofmt -s -w .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
+.PHONY: test lint vet fmt
+
 test:
 	go test -v ./...
+
 lint:
 	golangci-lint run
+
+vet:
+	go vet ./...
+
+fmt:
+	gofmt -w .


### PR DESCRIPTION
## Summary
- CI: `go vet`, `go test -race`, `go build -tags memebridge_tzdata ./...`
- Pin golangci-lint v2.11.4 with in-repo `.golangci.yml`
- Dependabot weekly updates for `go.mod`
- Makefile: `.PHONY`, `vet` and `fmt` targets

## FEEDBACK items covered
- CI / tooling section (vet, race, tzdata build, golangci pin, Dependabot, Makefile)

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] `go test -race ./...`
- [x] `go build -tags memebridge_tzdata ./...`

Made with [Cursor](https://cursor.com)