### PR TITLE
Export ErrUnsupportedExpr and ErrUnsupportedCast

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -33,7 +33,9 @@ const (
 )
 
 var (
-	errUnsupportedCast = errors.New("unsupported cast")
+	// ErrUnsupportedCast is returned when CAST cannot convert between the
+	// source and destination Spanner types.
+	ErrUnsupportedCast = errors.New("unsupported cast")
 
 	numericScaleFactor = pow10Int(spanner.NumericScaleDigits)
 	maxScaledNumeric   = new(big.Int).Sub(pow10Int(spanner.NumericPrecisionDigits), big.NewInt(1))
@@ -82,7 +84,7 @@ func memefishCastExprToGCV(cast *ast.CastExpr) (spanner.GenericColumnValue, erro
 	if err == nil {
 		return gcv, nil
 	}
-	if cast.Safe && !errors.Is(err, errUnsupportedCast) {
+	if cast.Safe && !errors.Is(err, ErrUnsupportedCast) {
 		return gcvctor.NullOf(destType), nil
 	}
 	return zeroGCV, err
@@ -1071,7 +1073,7 @@ func formatSpannerFloat(v float64, bitSize int) string {
 }
 
 func unsupportedCastError(srcCode, destCode sppb.TypeCode, exprSQL string) error {
-	err := fmt.Errorf("%w from %v to %v", errUnsupportedCast, srcCode, destCode)
+	err := fmt.Errorf("%w from %v to %v", ErrUnsupportedCast, srcCode, destCode)
 	if exprSQL != "" {
 		return fmt.Errorf("%w: %s", err, exprSQL)
 	}
@@ -1089,7 +1091,7 @@ func unsupportedArrayCastError(srcType, destType *sppb.Type, exprSQL string) err
 	if destElemType != nil {
 		destElemCode = destElemType.GetCode()
 	}
-	err := fmt.Errorf("%w from ARRAY<%v> to ARRAY<%v>", errUnsupportedCast, srcElemCode, destElemCode)
+	err := fmt.Errorf("%w from ARRAY<%v> to ARRAY<%v>", ErrUnsupportedCast, srcElemCode, destElemCode)
 	if exprSQL != "" {
 		return fmt.Errorf("%w: %s", err, exprSQL)
 	}

--- a/meme_to_sppb_type.go
+++ b/meme_to_sppb_type.go
@@ -82,6 +82,6 @@ func MemefishTypeToSpannerpbType(typ ast.Type) (*sppb.Type, error) {
 		}
 		return nil, fmt.Errorf("not known whether the named type is STRUCT or ENUM: %s", t.SQL())
 	default:
-		return nil, fmt.Errorf("%w: %s", ErrUnsupportedExpr, t.SQL())
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedType, t.SQL())
 	}
 }

--- a/meme_to_sppb_type.go
+++ b/meme_to_sppb_type.go
@@ -82,6 +82,6 @@ func MemefishTypeToSpannerpbType(typ ast.Type) (*sppb.Type, error) {
 		}
 		return nil, fmt.Errorf("not known whether the named type is STRUCT or ENUM: %s", t.SQL())
 	default:
-		return nil, fmt.Errorf("not implemented: %s", t.SQL())
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedExpr, t.SQL())
 	}
 }

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -30,6 +30,9 @@ var (
 	// ErrUnsupportedExpr is returned when MemefishExprToGCV encounters an
 	// expression kind it does not evaluate.
 	ErrUnsupportedExpr = errors.New("unsupported expression")
+	// ErrUnsupportedType is returned when MemefishTypeToSpannerpbType encounters a
+	// type kind it does not support.
+	ErrUnsupportedType = errors.New("unsupported type")
 	zeroGCV            spanner.GenericColumnValue
 )
 

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -24,8 +24,13 @@ import (
 const commitTimestampPlaceholderString = "spanner.commit_timestamp()"
 
 var (
+	// ErrCannotInferArrayElementType is returned when an untyped array literal
+	// has no inferrable element type.
 	ErrCannotInferArrayElementType = errors.New("cannot infer element type for array literal without explicit type")
-	zeroGCV                        spanner.GenericColumnValue
+	// ErrUnsupportedExpr is returned when MemefishExprToGCV encounters an
+	// expression kind it does not evaluate.
+	ErrUnsupportedExpr = errors.New("unsupported expression")
+	zeroGCV            spanner.GenericColumnValue
 )
 
 func typelessStructLiteralArgToNameWithGCV(arg ast.TypelessStructLiteralArg) (string, spanner.GenericColumnValue, error) {
@@ -399,7 +404,7 @@ func MemefishExprToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 	default:
 		// break
 	}
-	return zeroGCV, fmt.Errorf("not implemented: %s", expr.SQL())
+	return zeroGCV, fmt.Errorf("%w: %s", ErrUnsupportedExpr, expr.SQL())
 }
 
 func arrayLiteralToGCV(


### PR DESCRIPTION
## Summary
- Export `ErrUnsupportedExpr` for unhandled expression/type kinds
- Export `ErrUnsupportedCast` (replaces unexported sentinel)
- Wrap consistently in `MemefishExprToGCV`, `MemefishTypeToSpannerpbType`, and cast paths

Additive only; downstream can use `errors.Is` for fallback behavior.

## FEEDBACK items covered
- Error taxonomy proposal (public API surface #3)

## Test plan
- [x] `make test`
- [x] `make lint`

Made with [Cursor](https://cursor.com)