### PR TITLE
Add package godoc, exported comments, and examples

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,42 @@
+// Package memebridge converts memefish GoogleSQL AST nodes into Cloud Spanner
+// types and values.
+//
+// The conversion pipeline is:
+//
+//	GoogleSQL text → memefish.ParseExpr / ParseType → ast.Expr / ast.Type
+//	→ memebridge → spannerpb.Type + spanner.GenericColumnValue
+//
+// memebridge evaluates literal expressions (including CAST and SAFE_CAST),
+// applies expected-type coercion for STRUCT fields and ARRAY elements, and
+// maps memefish types to spannerpb.Type via spantype/typector. GCV wire
+// assembly uses spanvalue/gcvctor.
+//
+// # Entry points
+//
+// ParseExpr parses a SQL expression string and returns a GenericColumnValue.
+// MemefishExprToGCV converts an already-parsed ast.Expr. MemefishTypeToSpannerpbType
+// maps ast.Type to spannerpb.Type.
+//
+// The cliparams subpackage parses CLI-style name:value parameter assignments.
+//
+// # Semantic source of truth
+//
+// Literal evaluation and CAST behavior aim to match Cloud Spanner (and
+// googlesql cast tables). Temporal casts without an explicit time zone use
+// America/Los_Angeles. Build with the memebridge_tzdata tag to embed IANA
+// tzdata on minimal runtimes.
+//
+// # Special contracts
+//
+// PENDING_COMMIT_TIMESTAMP() is recognized case-insensitively and yields a
+// TIMESTAMP GenericColumnValue whose string wire value is the placeholder
+// "spanner.commit_timestamp()". Downstream Spanner clients interpret this
+// sentinel; memebridge preserves it through TIMESTAMP→STRING casts.
+//
+// Array literals use a permissive fallback when element values cannot be coerced
+// to the declared or inferred element type: the resulting GCV is typed as
+// ARRAY<T> but may retain original element wire values that do not match T.
+// This preserves pre-v0.3 behavior for callers that defer validation to the
+// server. Strict coercion is used on expected-type paths (typed STRUCT fields,
+// ARRAY<T> annotations).
+package memebridge

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,0 +1,71 @@
+package memebridge_test
+
+import (
+	"fmt"
+
+	"github.com/apstndb/memebridge"
+	"github.com/cloudspannerecosystem/memefish"
+)
+
+func ExampleParseExpr() {
+	gcv, err := memebridge.ParseExpr("", `CAST(42 AS STRING)`)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(gcv.Type.GetCode(), gcv.Value.GetStringValue())
+	// Output: STRING 42
+}
+
+func ExampleMemefishExprToGCV() {
+	expr, err := memefish.ParseExpr("", `STRUCT(1 AS x, ["a", "b"] AS tags)`)
+	if err != nil {
+		panic(err)
+	}
+	gcv, err := memebridge.MemefishExprToGCV(expr)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(gcv.Type.GetStructType().GetFields()[0].GetName())
+	fmt.Println(gcv.Type.GetStructType().GetFields()[1].GetType().GetArrayElementType().GetCode())
+	// Output: x
+	// STRING
+}
+
+func ExampleMemefishExprToGCV_cast() {
+	expr, err := memefish.ParseExpr("", `CAST(TRUE AS STRING)`)
+	if err != nil {
+		panic(err)
+	}
+	gcv, err := memebridge.MemefishExprToGCV(expr)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(gcv.Type.GetCode(), gcv.Value.GetStringValue())
+	// Output: STRING true
+}
+
+func ExampleMemefishExprToGCV_array() {
+	expr, err := memefish.ParseExpr("", `ARRAY<INT64>[1, 2, 3]`)
+	if err != nil {
+		panic(err)
+	}
+	gcv, err := memebridge.MemefishExprToGCV(expr)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(gcv.Type.GetCode(), gcv.Type.GetArrayElementType().GetCode())
+	// Output: ARRAY INT64
+}
+
+func ExampleMemefishExprToGCV_pendingCommitTimestamp() {
+	expr, err := memefish.ParseExpr("", `PENDING_COMMIT_TIMESTAMP()`)
+	if err != nil {
+		panic(err)
+	}
+	gcv, err := memebridge.MemefishExprToGCV(expr)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(gcv.Type.GetCode())
+	// Output: TIMESTAMP
+}

--- a/meme_to_sppb_type.go
+++ b/meme_to_sppb_type.go
@@ -9,6 +9,12 @@ import (
 	"github.com/cloudspannerecosystem/memefish/ast"
 )
 
+// ScalarTypeNameToTypeCodeMap maps memefish scalar type names to Spanner
+// TypeCode values. UUID is not included because memefish models it as a
+// NamedType, not a ScalarTypeName; see MemefishTypeToSpannerpbType.
+//
+// Treat this map as read-only; mutating it changes conversion behavior
+// process-wide.
 var ScalarTypeNameToTypeCodeMap = map[ast.ScalarTypeName]sppb.TypeCode{
 	ast.BoolTypeName:      sppb.TypeCode_BOOL,
 	ast.Int64TypeName:     sppb.TypeCode_INT64,
@@ -47,6 +53,9 @@ func memefishStructFieldToStructTypeField(field *ast.StructField) (*sppb.StructT
 	return typector.NameTypeToStructTypeField(fieldNameOrEmpty(field), t), nil
 }
 
+// MemefishTypeToSpannerpbType maps a memefish ast.Type to spannerpb.Type.
+// Named types other than UUID require disambiguation between STRUCT and ENUM
+// and currently return an error until descriptor support is added.
 func MemefishTypeToSpannerpbType(typ ast.Type) (*sppb.Type, error) {
 	switch t := typ.(type) {
 	case *ast.SimpleType:

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -25,7 +25,8 @@ const commitTimestampPlaceholderString = "spanner.commit_timestamp()"
 
 var (
 	// ErrCannotInferArrayElementType is returned when an untyped array literal
-	// has no inferrable element type.
+	// has no inferrable element type (for example, an empty array with no
+	// explicit ARRAY<T> annotation).
 	ErrCannotInferArrayElementType = errors.New("cannot infer element type for array literal without explicit type")
 	// ErrUnsupportedExpr is returned when MemefishExprToGCV encounters an
 	// expression kind it does not evaluate.
@@ -354,6 +355,13 @@ func extractValues(expr ast.Expr) ([]ast.Expr, error) {
 	}
 }
 
+// MemefishExprToGCV evaluates a memefish expression AST node to a
+// GenericColumnValue. It handles literals, STRUCT and ARRAY literals, CAST and
+// SAFE_CAST, INTERVAL literals, and PENDING_COMMIT_TIMESTAMP().
+//
+// Unsupported expression kinds return an error. Array literals may use a
+// permissive wire fallback when elements cannot be coerced to the declared or
+// inferred element type; see package documentation.
 func MemefishExprToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 	switch e := expr.(type) {
 	case *ast.NullLiteral:

--- a/memestr_to_sppb_value.go
+++ b/memestr_to_sppb_value.go
@@ -5,6 +5,9 @@ import (
 	"github.com/cloudspannerecosystem/memefish"
 )
 
+// ParseExpr parses a GoogleSQL expression string and evaluates it to a
+// GenericColumnValue. The filepath argument is passed to memefish for error
+// positions only; an empty string is fine when positions are not needed.
 func ParseExpr(filepath, s string) (spanner.GenericColumnValue, error) {
 	expr, err := memefish.ParseExpr(filepath, s)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `doc.go` with package overview (pipeline, tzdata, PENDING_COMMIT_TIMESTAMP, permissive ARRAY contract)
- Doc comments on exported symbols: `ParseExpr`, `MemefishExprToGCV`, `MemefishTypeToSpannerpbType`, `ScalarTypeNameToTypeCodeMap`, `ErrCannotInferArrayElementType`
- Runnable examples: `ExampleParseExpr`, `ExampleMemefishExprToGCV` (+ cast/array/PENDING_COMMIT_TIMESTAMP variants)

## FEEDBACK items covered
- Public API surface #1 (godoc gap)
- Permissive ARRAY and PENDING_COMMIT_TIMESTAMP contracts in godoc

## Test plan
- [x] `make test` (includes Example tests)
- [x] `make lint`

Made with [Cursor](https://cursor.com)