### PR TITLE
Small parity and cleanup fixes

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -791,12 +791,27 @@ func isDecimalNumericString(v string) bool {
 
 func parseSpannerInt64(v string) (int64, error) {
 	v = strings.TrimSpace(v)
+	sign := int64(1)
 	unsigned := v
-	if strings.HasPrefix(unsigned, "+") || strings.HasPrefix(unsigned, "-") {
+	if strings.HasPrefix(unsigned, "+") {
+		unsigned = unsigned[1:]
+	} else if strings.HasPrefix(unsigned, "-") {
+		sign = -1
 		unsigned = unsigned[1:]
 	}
 	if strings.HasPrefix(unsigned, "0x") || strings.HasPrefix(unsigned, "0X") {
-		return strconv.ParseInt(v, 0, 64)
+		if strings.Contains(unsigned, "_") {
+			return 0, strconv.ErrSyntax
+		}
+		digits := unsigned[2:]
+		if digits == "" {
+			return 0, strconv.ErrSyntax
+		}
+		i, err := strconv.ParseInt(digits, 16, 64)
+		if err != nil {
+			return 0, err
+		}
+		return sign * i, nil
 	}
 	return strconv.ParseInt(v, 10, 64)
 }

--- a/interval.go
+++ b/interval.go
@@ -38,7 +38,7 @@ func formatNumericForInterval(r *big.Rat) string {
 	return strings.TrimRight(spanner.NumericString(r), "0")
 }
 
-func toRFC8601Duration(i int64, part ast.DateTimePart) (string, error) {
+func toISO8601Duration(i int64, part ast.DateTimePart) (string, error) {
 	if i == 0 {
 		return "P0Y", nil
 	}
@@ -152,7 +152,7 @@ func astIntervalLiteralsToInterval(expr ast.Expr) (spanner.Interval, error) {
 			return zero, err
 		}
 
-		durationString, err := toRFC8601Duration(i, e.DateTimePart)
+		durationString, err := toISO8601Duration(i, e.DateTimePart)
 		if err != nil {
 			return zero, err
 		}

--- a/meme_to_sppb_type.go
+++ b/meme_to_sppb_type.go
@@ -74,6 +74,8 @@ func MemefishTypeToSpannerpbType(typ ast.Type) (*sppb.Type, error) {
 
 		return typector.StructTypeFieldsToStructType(fields), nil
 	case *ast.NamedType:
+		// UUID is a NamedType in memefish, not a ScalarTypeName, so it is
+		// handled here rather than in ScalarTypeNameToTypeCodeMap.
 		if len(t.Path) == 1 {
 			switch strings.ToUpper(t.Path[0].Name) {
 			case "UUID":

--- a/meme_to_sppb_value.go
+++ b/meme_to_sppb_value.go
@@ -65,15 +65,13 @@ func astStructLiteralsToGCV(expr ast.Expr) (spanner.GenericColumnValue, error) {
 			if err != nil {
 				return zeroGCV, err
 			}
-			// fields = append(fields, typector.NameTypeToStructTypeField(name, gcv.Type))
-			// values = append(values, gcv.Value)
 			names = append(names, name)
 			gcvs = append(gcvs, gcv)
 		}
 	case *ast.TupleStructLiteral:
 		astValues, err := extractValues(e)
 		if err != nil {
-			return zeroGCV, errors.New("invalid state")
+			return zeroGCV, fmt.Errorf("tuple struct literal: %w", err)
 		}
 
 		gcvs, err = lo.MapErr(astValues, func(expr ast.Expr, _ int) (spanner.GenericColumnValue, error) {


### PR DESCRIPTION
## Summary
- Remove dead commented code in `astStructLiteralsToGCV`
- Return wrapped error from tuple struct `extractValues` failure (not "invalid state")
- `parseSpannerInt64`: reject underscores in hex literals (Spanner parity)
- Rename `toRFC8601Duration` → `toISO8601Duration`
- Document UUID `NamedType` handling vs `ScalarTypeNameToTypeCodeMap`

## FEEDBACK items covered
- meme_to_sppb_value.go findings #1–#2
- cast.go `parseSpannerInt64` hex underscore
- interval.go ISO 8601 rename
- meme_to_sppb_type.go UUID comment

## Test plan
- [x] `make test`
- [x] `make lint`

Made with [Cursor](https://cursor.com)