### PR TITLE
Centralize structpb null handling with private helpers

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -555,7 +555,7 @@ func castGCVToStruct(src spanner.GenericColumnValue, destType *sppb.Type, exprSQ
 }
 
 func isNullGCV(gcv spanner.GenericColumnValue) bool {
-	return spanvalue.IsNull(gcv)
+	return spanvalue.IsNull(gcv) || isNullValue(gcv.Value)
 }
 
 func boolFromGCV(gcv spanner.GenericColumnValue) (bool, error) {

--- a/gcv_helpers.go
+++ b/gcv_helpers.go
@@ -2,19 +2,36 @@ package memebridge
 
 import (
 	"cloud.google.com/go/spanner"
-	"github.com/apstndb/spanvalue"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+// isNullValue reports whether v represents SQL NULL on the wire.
+// Both absent values (nil) and explicit protobuf null are treated as null.
+func isNullValue(v *structpb.Value) bool {
+	if v == nil {
+		return true
+	}
+	_, ok := v.GetKind().(*structpb.Value_NullValue)
+	return ok
+}
+
+// normalizeValue returns an explicit protobuf null for absent wire values.
+func normalizeValue(v *structpb.Value) *structpb.Value {
+	if isNullValue(v) {
+		return structpb.NewNullValue()
+	}
+	return v
+}
 
 // gcvToProtoValue is an unexported prototype for a requested root spanvalue API
 // (not gcvctor — result is *structpb.Value, not GenericColumnValue):
 // spanvalue.ToProtoValue(gcv spanner.GenericColumnValue) *structpb.Value.
 // It materializes protobuf NULL for SQL NULL cells before ARRAY/STRUCT assembly.
 func gcvToProtoValue(gcv spanner.GenericColumnValue) *structpb.Value {
-	if spanvalue.IsNull(gcv) {
+	if isNullGCV(gcv) {
 		return structpb.NewNullValue()
 	}
-	return gcv.Value
+	return normalizeValue(gcv.Value)
 }
 
 // gcvArrayWireValues is an unexported prototype for a requested root spanvalue API


### PR DESCRIPTION
## Summary

Centralize `structpb.Value` null handling through private `isNullValue` and `normalizeValue` helpers, and extend `isNullGCV` to treat absent wire values consistently with explicit protobuf null.

## Changes

- Add `isNullValue` — true for both `nil` and explicit `*structpb.Value_NullValue`
- Add `normalizeValue` — materializes absent values as `structpb.NewNullValue()`
- Route `gcvToProtoValue` through the helpers for nested ARRAY / STRUCT assembly
- Extend `isNullGCV` to cover absent wire values alongside `spanvalue.IsNull`

## Behavior

- Read paths treat `nil` and explicit protobuf null as the same logical null
- Write paths normalize outgoing null entries to `structpb.NewNullValue()`
- Typed NULL propagation in `spanner.GenericColumnValue` is unchanged

## Test plan

- [x] `make test`
- [x] `make lint`

Closes #33.

Made with [Cursor](https://cursor.com)