### PR TITLE
v0.7: Rename ParseExpr and remove ScalarTypeNameToTypeCodeMap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ There is no standalone binary build target; this project is validated through te
 
 ## Architecture
 
-- `ParseExpr` in `memestr_to_sppb_value.go` is the string entry point: it parses with `memefish.ParseExpr` and delegates to `MemefishExprToGCV`.
+- `ParseExprToGCV` in `memestr_to_sppb_value.go` is the string entry point: it parses with `memefish.ParseExpr` and delegates to `MemefishExprToGCV`.
 - `meme_to_sppb_value.go` is the main AST-to-`spanner.GenericColumnValue` layer. It handles literal evaluation, typed STRUCT/ARRAY expected-type coercion, and array element type inference.
 - `cast.go` is the single place for explicit `CAST` / `SAFE_CAST` behavior, typed NULL propagation, scalar conversion rules, ARRAY/STRUCT cast rules, numeric parsing, and temporal conversion defaults.
 - `meme_to_sppb_type.go` maps `memefish` types to `spannerpb.Type`; coercion and cast logic relies on those exact type objects.
@@ -34,7 +34,7 @@ When `type.proto` gains a `TypeCode` before memefish, spanvalue, or memebridge c
 | **spanvalue** | Dedicated constructors may be missing; scalar wire passthrough may still work for transport-only paths |
 | **memebridge** | Explicit error on type mapping, evaluation, or CAST — no guessing |
 
-Upper layers are stricter. Lower layers may be permissive only when shuttling already-valid wire without interpreting it. In memebridge: unknown scalar names error in `meme_to_sppb_type.go`; unhandled expressions return `ErrUnsupportedExpr`; unhandled cast pairs return `ErrUnsupportedCast`; return `ParseExpr` / `ParseType` errors from memefish unchanged.
+Upper layers are stricter. Lower layers may be permissive only when shuttling already-valid wire without interpreting it. In memebridge: unknown scalar names error in `meme_to_sppb_type.go`; unhandled expressions return `ErrUnsupportedExpr`; unhandled cast pairs return `ErrUnsupportedCast`; return `ParseExprToGCV` / `ParseType` errors from memefish unchanged.
 
 **Anti-patterns (all layers):** mapping unknown `TypeCode` to `TYPE_CODE_UNSPECIFIED`; silent coercion to `INT64` or `STRING` (except the documented bare-`NULL` → typed `INT64` NULL Spanner parity rule); unchecked `WithType` on semantic paths to hide missing support; assuming a `spannerpb` `go.mod` bump alone enables end-user SQL for a new type.
 

--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,8 @@
 //
 // # Entry points
 //
-// ParseExpr parses a SQL expression string and returns a GenericColumnValue.
+// ParseExprToGCV parses a SQL expression string and returns a GenericColumnValue.
+// ParseExprFile is the same with a filename for memefish error positions.
 // MemefishExprToGCV converts an already-parsed ast.Expr. MemefishTypeToSpannerpbType
 // maps ast.Type to spannerpb.Type.
 //

--- a/examples_test.go
+++ b/examples_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cloudspannerecosystem/memefish"
 )
 
-func ExampleParseExpr() {
-	gcv, err := memebridge.ParseExpr("", `CAST(42 AS STRING)`)
+func ExampleParseExprToGCV() {
+	gcv, err := memebridge.ParseExprToGCV(`CAST(42 AS STRING)`)
 	if err != nil {
 		panic(err)
 	}

--- a/meme_to_sppb_type.go
+++ b/meme_to_sppb_type.go
@@ -9,13 +9,19 @@ import (
 	"github.com/cloudspannerecosystem/memefish/ast"
 )
 
-// ScalarTypeNameToTypeCodeMap maps memefish scalar type names to Spanner
-// TypeCode values. UUID is not included because memefish models it as a
-// NamedType, not a ScalarTypeName; see MemefishTypeToSpannerpbType.
-//
-// Deprecated: use [ScalarTypeNameToTypeCode] instead. Treat this map as
-// read-only; mutating it changes conversion behavior process-wide.
-var ScalarTypeNameToTypeCodeMap = map[ast.ScalarTypeName]sppb.TypeCode{
+// ScalarTypeNameToTypeCode maps a memefish scalar type name to the
+// corresponding Spanner TypeCode. The second return value is false when the
+// name is not a known scalar type (for example UUID, which memefish models as
+// a NamedType).
+func ScalarTypeNameToTypeCode(name ast.ScalarTypeName) (sppb.TypeCode, bool) {
+	code, ok := scalarTypeNameToTypeCode[name]
+	return code, ok
+}
+
+// scalarTypeNameToTypeCode maps memefish scalar type names to Spanner TypeCode
+// values. UUID is not included because memefish models it as a NamedType, not a
+// ScalarTypeName; see MemefishTypeToSpannerpbType.
+var scalarTypeNameToTypeCode = map[ast.ScalarTypeName]sppb.TypeCode{
 	ast.BoolTypeName:      sppb.TypeCode_BOOL,
 	ast.Int64TypeName:     sppb.TypeCode_INT64,
 	ast.Float64TypeName:   sppb.TypeCode_FLOAT64,
@@ -27,15 +33,6 @@ var ScalarTypeNameToTypeCodeMap = map[ast.ScalarTypeName]sppb.TypeCode{
 	ast.NumericTypeName:   sppb.TypeCode_NUMERIC,
 	ast.JSONTypeName:      sppb.TypeCode_JSON,
 	ast.IntervalTypeName:  sppb.TypeCode_INTERVAL,
-}
-
-// ScalarTypeNameToTypeCode maps a memefish scalar type name to the
-// corresponding Spanner TypeCode. The second return value is false when the
-// name is not a known scalar type (for example UUID, which memefish models as
-// a NamedType).
-func ScalarTypeNameToTypeCode(name ast.ScalarTypeName) (sppb.TypeCode, bool) {
-	code, ok := ScalarTypeNameToTypeCodeMap[name]
-	return code, ok
 }
 
 func memefishScalarTypeToSpannerpbType(typename ast.ScalarTypeName) (*sppb.Type, error) {
@@ -93,7 +90,7 @@ func MemefishTypeToSpannerpbType(typ ast.Type) (*sppb.Type, error) {
 		return typector.StructTypeFieldsToStructType(fields), nil
 	case *ast.NamedType:
 		// UUID is a NamedType in memefish, not a ScalarTypeName, so it is
-		// handled here rather than in ScalarTypeNameToTypeCodeMap.
+		// handled here rather than in scalarTypeNameToTypeCode.
 		if len(t.Path) == 1 {
 			switch strings.ToUpper(t.Path[0].Name) {
 			case "UUID":

--- a/memestr_to_sppb_value.go
+++ b/memestr_to_sppb_value.go
@@ -5,14 +5,19 @@ import (
 	"github.com/cloudspannerecosystem/memefish"
 )
 
-// ParseExpr parses a GoogleSQL expression string and evaluates it to a
-// GenericColumnValue. The filepath argument is passed to memefish for error
-// positions only; an empty string is fine when positions are not needed.
-func ParseExpr(filepath, s string) (spanner.GenericColumnValue, error) {
-	expr, err := memefish.ParseExpr(filepath, s)
+// ParseExprToGCV parses a GoogleSQL expression string and evaluates it to a
+// GenericColumnValue.
+func ParseExprToGCV(expr string) (spanner.GenericColumnValue, error) {
+	return ParseExprFile("", expr)
+}
+
+// ParseExprFile is like [ParseExprToGCV] but passes filename to memefish for
+// error positions only.
+func ParseExprFile(filename, expr string) (spanner.GenericColumnValue, error) {
+	astExpr, err := memefish.ParseExpr(filename, expr)
 	if err != nil {
 		return spanner.GenericColumnValue{}, err
 	}
 
-	return MemefishExprToGCV(expr)
+	return MemefishExprToGCV(astExpr)
 }

--- a/memestr_to_sppb_value_test.go
+++ b/memestr_to_sppb_value_test.go
@@ -527,7 +527,7 @@ func TestParseExpr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := memebridge.ParseExpr("", tt.input)
+			got, err := memebridge.ParseExprToGCV(tt.input)
 			if err != nil {
 				t.Errorf("should not fail, but err: %v", err)
 			}
@@ -547,7 +547,7 @@ func TestParseExpr(t *testing.T) {
 		}
 		safeInput := tt.input[:idx] + "SAFE_CAST(" + tt.input[idx+len("CAST("):]
 		t.Run(safeInput, func(t *testing.T) {
-			got, err := memebridge.ParseExpr("", safeInput)
+			got, err := memebridge.ParseExprToGCV(safeInput)
 			if err != nil {
 				t.Errorf("should not fail, but err: %v", err)
 			}
@@ -567,7 +567,7 @@ func TestParseExpr_Numeric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := memebridge.ParseExpr("", tt.input)
+			got, err := memebridge.ParseExprToGCV(tt.input)
 			if err != nil {
 				t.Errorf("should not fail, but err: %v", err)
 			}
@@ -585,7 +585,7 @@ func TestParseExpr_Numeric(t *testing.T) {
 }
 
 func TestParseExpr_AllParenthesizedNullArrayInfersInt64(t *testing.T) {
-	got, err := memebridge.ParseExpr("", "[(NULL)]")
+	got, err := memebridge.ParseExprToGCV("[(NULL)]")
 	if err != nil {
 		t.Fatalf("should not fail, but err: %v", err)
 	}
@@ -657,7 +657,7 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {
-			if _, err := memebridge.ParseExpr("", input); err == nil {
+			if _, err := memebridge.ParseExprToGCV(input); err == nil {
 				t.Fatal("expected error")
 			}
 		})
@@ -667,13 +667,13 @@ func TestParseExpr_InvalidCastReturnsError(t *testing.T) {
 func TestParseExpr_NumericCastUnderflowRoundsToZero(t *testing.T) {
 	input := `CAST("0.` + strings.Repeat("0", 1200) + `1" AS NUMERIC)`
 
-	got, err := memebridge.ParseExpr("", input)
+	got, err := memebridge.ParseExprToGCV(input)
 	if err != nil {
-		t.Fatalf("ParseExpr returned error: %v", err)
+		t.Fatalf("ParseExprToGCV returned error: %v", err)
 	}
 
 	want := gcvctor.NumericValue(big.NewRat(0, 1))
 	if diff := cmp.Diff(want, got, protocmp.Transform(), cmpopts.EquateNaNs()); diff != "" {
-		t.Fatalf("ParseExpr mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ParseExprToGCV mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary

Breaking API cleanup for v0.7 (closes #37, closes #40).

- Rename `ParseExpr(filepath, s)` → `ParseExprToGCV(expr)` with `ParseExprFile(filename, expr)` for memefish error positions
- Remove deprecated exported `ScalarTypeNameToTypeCodeMap`; use `ScalarTypeNameToTypeCode` only (map is now private)

No downstream importers use `ParseExpr` or the exported map (verified via repo grep).

## Breaking changes

- `ParseExpr` removed — migrate to `ParseExprToGCV` or `ParseExprFile`
- `ScalarTypeNameToTypeCodeMap` removed — migrate to `ScalarTypeNameToTypeCode(name)`

## Test plan

- [x] `make test`
- [x] `make lint`


Made with [Cursor](https://cursor.com)